### PR TITLE
feat: improve logging signal-to-noise for condition transitions and API errors

### DIFF
--- a/internal/controller/engine_controller.go
+++ b/internal/controller/engine_controller.go
@@ -135,7 +135,7 @@ func (r *EngineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			return ctrl.Result{}, nil
 		}
 
-		logError(log, req, "Engine", err, "Failed to get")
+		logAPIError(log, req, "Engine", err, "Failed to get", nil)
 		return ctrl.Result{}, err
 	}
 
@@ -165,7 +165,7 @@ func (r *EngineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		patch := client.MergeFrom(engine.DeepCopy())
 		setStatusProgressing(log, req, "Engine", &engine.Status.Conditions, engine.Generation, "Reconciling", "Starting reconciliation")
 		if err := r.Status().Patch(ctx, &engine, patch); err != nil {
-			logError(log, req, "Engine", err, "Failed to patch initial status")
+			logAPIError(log, req, "Engine", err, "Failed to patch initial status", &engine)
 			return ctrl.Result{}, err
 		}
 	}
@@ -235,7 +235,7 @@ func (r *EngineReconciler) isRuleSetDegraded(ctx context.Context, log logr.Logge
 			}
 			return true, nil
 		}
-		logError(log, req, "Engine", err, "Failed to get RuleSet")
+		logAPIError(log, req, "Engine", err, "Failed to get RuleSet", engine)
 		return false, fmt.Errorf("failed to get RuleSet %s: %w", engine.Spec.RuleSet.Name, err)
 	}
 	if ruleSet.Status == nil {

--- a/internal/controller/engine_controller_driver_istio.go
+++ b/internal/controller/engine_controller_driver_istio.go
@@ -78,7 +78,7 @@ func (r *EngineReconciler) provisionIstioEngineWithWasm(ctx context.Context, log
 	logDebug(log, req, "Engine", "Finding matched Gateways")
 	gateways, gwErr := r.matchedGateways(ctx, log, req, &engine)
 	if gwErr != nil {
-		logError(log, req, "Engine", gwErr, "Failed to find matched Gateways, not updating Gateway status")
+		logAPIError(log, req, "Engine", gwErr, "Failed to find matched Gateways, not updating Gateway status", &engine)
 	}
 
 	// Status patching is kept inline because it mutates engine.Status.Gateways
@@ -90,7 +90,7 @@ func (r *EngineReconciler) provisionIstioEngineWithWasm(ctx context.Context, log
 	}
 	setStatusReady(log, req, "Engine", &engine.Status.Conditions, engine.Generation, "Configured", "WasmPlugin successfully created/updated")
 	if err := r.Status().Patch(ctx, &engine, patch); err != nil {
-		logError(log, req, "Engine", err, "Failed to patch status")
+		logAPIError(log, req, "Engine", err, "Failed to patch status", &engine)
 		return ctrl.Result{}, err
 	}
 	r.Recorder.Eventf(&engine, nil, "Normal", "WasmPluginCreated", "Provision", "Created WasmPlugin %s/%s", wasmPlugin.GetNamespace(), wasmPlugin.GetName())
@@ -118,7 +118,7 @@ func (r *EngineReconciler) applyWasmPlugin(ctx context.Context, log logr.Logger,
 
 	logDebug(log, req, "Engine", "Applying WasmPlugin", "wasmPluginName", wasmPlugin.GetName())
 	if err := serverSideApply(ctx, r.Client, wasmPlugin); err != nil {
-		logError(log, req, "Engine", err, "Failed to create or update WasmPlugin")
+		logAPIError(log, req, "Engine", err, "Failed to create or update WasmPlugin", engine)
 		return nil, err
 	}
 

--- a/internal/controller/ruleset_controller.go
+++ b/internal/controller/ruleset_controller.go
@@ -113,7 +113,7 @@ func (r *RuleSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			logDebug(log, req, "RuleSet", "Resource not found")
 			return ctrl.Result{}, nil
 		}
-		logError(log, req, "RuleSet", err, "Failed to GET")
+		logAPIError(log, req, "RuleSet", err, "Failed to GET", nil)
 		return ctrl.Result{}, err
 	}
 
@@ -175,7 +175,7 @@ func (r *RuleSetReconciler) initializeStatus(ctx context.Context, log logr.Logge
 	patch := client.MergeFrom(ruleset.DeepCopy())
 	setStatusProgressing(log, req, "RuleSet", &ruleset.Status.Conditions, ruleset.Generation, "Reconciling", "Starting reconciliation")
 	if err := r.Status().Patch(ctx, ruleset, patch); err != nil {
-		logError(log, req, "RuleSet", err, "Failed to patch initial status")
+		logAPIError(log, req, "RuleSet", err, "Failed to patch initial status", ruleset)
 		return err
 	}
 	return nil

--- a/internal/controller/ruleset_controller_rule_aggregation.go
+++ b/internal/controller/ruleset_controller_rule_aggregation.go
@@ -81,7 +81,7 @@ func (r *RuleSetReconciler) fetchConfigMapRules(
 			}
 			return "", false, true, nil
 		}
-		logError(log, req, "RuleSet", err, "Failed to get ConfigMap", "configMapName", configMapName)
+		logAPIError(log, req, "RuleSet", err, "Failed to get ConfigMap", ruleset, "configMapName", configMapName)
 		msg := fmt.Sprintf("Failed to access ConfigMap %s: %v", configMapName, err)
 		if patchErr := patchDegraded(ctx, r.Status(), r.Recorder, log, req, "RuleSet", ruleset, &ruleset.Status.Conditions, ruleset.Generation, "ConfigMapAccessError", msg); patchErr != nil {
 			return "", false, true, patchErr

--- a/internal/controller/ruleset_controller_secret_data.go
+++ b/internal/controller/ruleset_controller_secret_data.go
@@ -83,7 +83,7 @@ func (r *RuleSetReconciler) loadRuleDataSecret(
 		}
 		return nil, true, nil
 	default:
-		logError(log, req, "RuleSet", err, "Failed to access RuleData secret", "secretName", ruleDataName)
+		logAPIError(log, req, "RuleSet", err, "Failed to access RuleData secret", ruleset, "secretName", ruleDataName)
 		msg := fmt.Sprintf("Failed to access RuleData secret %s: %v", ruleDataName, err)
 		if patchErr := patchDegraded(ctx, r.Status(), r.Recorder, log, req, "RuleSet", ruleset, &ruleset.Status.Conditions, ruleset.Generation, "SecretAccessError", msg); patchErr != nil {
 			return nil, true, patchErr

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -61,9 +62,103 @@ func logError(log logr.Logger, req ctrl.Request, kind string, err error, msg str
 	log.Error(err, fmt.Sprintf("%s: %s", kind, msg), args...)
 }
 
+// logAPIError logs an error from a Kubernetes API call, enriching it with
+// resourceVersion (from obj, when non-nil), HTTP status code, API reason,
+// and retryAfterSeconds when the error is or wraps a *apierrors.StatusError.
+//
+// Workqueue retry/attempt count is not available inside Reconcile without a
+// cross-cutting wrapper or metrics integration; that is left for a follow-up.
+func logAPIError(log logr.Logger, req ctrl.Request, kind string, err error, msg string, obj client.Object, extra ...any) {
+	args := append([]any{"namespace", req.Namespace, "name", req.Name}, extra...)
+
+	if obj != nil {
+		if rv := obj.GetResourceVersion(); rv != "" {
+			args = append(args, "resourceVersion", rv)
+		}
+	}
+
+	args = append(args, extractStatusErrorFields(err)...)
+	log.Error(err, fmt.Sprintf("%s: %s", kind, msg), args...)
+}
+
+// extractStatusErrorFields returns structured key/value pairs from a
+// *apierrors.StatusError if err is or wraps one.
+func extractStatusErrorFields(err error) []any {
+	var statusErr *apierrors.StatusError
+	if !errors.As(err, &statusErr) {
+		return nil
+	}
+
+	st := statusErr.Status()
+	fields := []any{
+		"apiStatusCode", st.Code,
+		"apiReason", string(st.Reason),
+	}
+
+	if st.Details != nil && st.Details.RetryAfterSeconds > 0 {
+		fields = append(fields, "retryAfterSeconds", st.Details.RetryAfterSeconds)
+	}
+
+	return fields
+}
+
 // -----------------------------------------------------------------------------
 // Status Condition Helpers
 // -----------------------------------------------------------------------------
+
+// trackedConditionTypes are the operator-owned condition types whose transitions
+// are logged at Info level.
+var trackedConditionTypes = []string{"Ready", "Degraded", "Progressing"}
+
+// conditionSnapshot captures the Status and Reason of each tracked condition
+// type before mutation. A nil entry means the condition was absent.
+type conditionSnapshot map[string]*metav1.Condition
+
+func snapshotConditions(conditions []metav1.Condition) conditionSnapshot {
+	snap := make(conditionSnapshot, len(trackedConditionTypes))
+	for _, ct := range trackedConditionTypes {
+		if c := apimeta.FindStatusCondition(conditions, ct); c != nil {
+			cpy := *c
+			snap[ct] = &cpy
+		}
+	}
+	return snap
+}
+
+// logConditionTransitions compares before and after snapshots and logs at Info
+// for each tracked condition whose Status changed, appeared, or disappeared.
+// Idempotent no-ops (same Status+Reason) are silent.
+func logConditionTransitions(log logr.Logger, req ctrl.Request, kind string, before conditionSnapshot, after []metav1.Condition) {
+	for _, ct := range trackedConditionTypes {
+		prev := before[ct]
+		cur := apimeta.FindStatusCondition(after, ct)
+
+		switch {
+		case prev == nil && cur == nil:
+			continue
+		case prev == nil && cur != nil:
+			logInfo(log, req, kind, "Condition set",
+				"condition", ct,
+				"fromStatus", "",
+				"toStatus", string(cur.Status),
+				"reason", cur.Reason)
+		case prev != nil && cur == nil:
+			logInfo(log, req, kind, "Condition removed",
+				"condition", ct,
+				"fromStatus", string(prev.Status),
+				"toStatus", "")
+		default:
+			if prev.Status == cur.Status && prev.Reason == cur.Reason {
+				continue
+			}
+			logInfo(log, req, kind, "Condition changed",
+				"condition", ct,
+				"fromStatus", string(prev.Status),
+				"toStatus", string(cur.Status),
+				"reason", cur.Reason)
+		}
+	}
+}
 
 // setConditionTrue is a helper function to set metav1.Conditions to True.
 func setConditionTrue(conditions *[]metav1.Condition, generation int64, conditionType, reason, message string) {
@@ -91,17 +186,19 @@ func setConditionFalse(conditions *[]metav1.Condition, generation int64, conditi
 
 // setStatusConditionDegraded is a helper to mark a resource as degraded.
 func setStatusConditionDegraded(log logr.Logger, req ctrl.Request, kind string, conditions *[]metav1.Condition, generation int64, reason, message string) {
-	logDebug(log, req, kind, fmt.Sprintf("Setting degraded status: %s", reason))
+	before := snapshotConditions(*conditions)
 	setConditionFalse(conditions, generation, "Ready", reason, message)
 	setConditionTrue(conditions, generation, "Degraded", reason, message)
 	apimeta.RemoveStatusCondition(conditions, "Progressing")
+	logConditionTransitions(log, req, kind, before, *conditions)
 }
 
 // setStatusProgressing is a helper to mark a resource as actively progressing.
 func setStatusProgressing(log logr.Logger, req ctrl.Request, kind string, conditions *[]metav1.Condition, generation int64, reason, message string) {
-	logDebug(log, req, kind, fmt.Sprintf("Setting progressing status: %s", reason))
+	before := snapshotConditions(*conditions)
 	setConditionFalse(conditions, generation, "Ready", reason, message)
 	setConditionTrue(conditions, generation, "Progressing", reason, message)
+	logConditionTransitions(log, req, kind, before, *conditions)
 }
 
 // maxEventNoteBytes is the maximum size of the note field in events.k8s.io/v1.
@@ -136,7 +233,7 @@ func patchDegraded(
 	patch := client.MergeFrom(obj.DeepCopyObject().(client.Object))
 	setStatusConditionDegraded(log, req, kind, conditions, generation, reason, message)
 	if err := statusWriter.Patch(ctx, obj, patch); err != nil {
-		logError(log, req, kind, err, "Failed to patch status")
+		logAPIError(log, req, kind, err, "Failed to patch status", obj)
 		return err
 	}
 	return nil
@@ -144,10 +241,11 @@ func patchDegraded(
 
 // setStatusReady is a helper to mark a resource as ready, fully reconciled.
 func setStatusReady(log logr.Logger, req ctrl.Request, kind string, conditions *[]metav1.Condition, generation int64, reason, message string) {
-	logDebug(log, req, kind, fmt.Sprintf("Setting ready status: %s", reason))
+	before := snapshotConditions(*conditions)
 	setConditionTrue(conditions, generation, "Ready", reason, message)
 	apimeta.RemoveStatusCondition(conditions, "Degraded")
 	apimeta.RemoveStatusCondition(conditions, "Progressing")
+	logConditionTransitions(log, req, kind, before, *conditions)
 }
 
 // patchReady marks a resource as Ready, emits a Normal event, and patches the
@@ -168,7 +266,7 @@ func patchReady(
 	patch := client.MergeFrom(obj.DeepCopyObject().(client.Object))
 	setStatusReady(log, req, kind, conditions, generation, reason, message)
 	if err := statusWriter.Patch(ctx, obj, patch); err != nil {
-		logError(log, req, kind, err, "Failed to patch status")
+		logAPIError(log, req, kind, err, "Failed to patch status", obj)
 		return err
 	}
 	return nil

--- a/internal/controller/utils_logging_test.go
+++ b/internal/controller/utils_logging_test.go
@@ -1,0 +1,337 @@
+/*
+Copyright Coraza Kubernetes Operator contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+// ---------------------------------------------------------------------------
+// captureSink — records log entries for assertions
+// ---------------------------------------------------------------------------
+
+type captureSink struct {
+	entries []logEntry
+}
+
+type logEntry struct {
+	Level         int // -1 for Error
+	Msg           string
+	KeysAndValues []any
+	Err           error
+}
+
+func (s *captureSink) Init(logr.RuntimeInfo)          {}
+func (s *captureSink) Enabled(int) bool                { return true }
+func (s *captureSink) WithValues(...any) logr.LogSink  { return s }
+func (s *captureSink) WithName(string) logr.LogSink    { return s }
+
+func (s *captureSink) Info(level int, msg string, keysAndValues ...any) {
+	s.entries = append(s.entries, logEntry{Level: level, Msg: msg, KeysAndValues: keysAndValues})
+}
+
+func (s *captureSink) Error(err error, msg string, keysAndValues ...any) {
+	s.entries = append(s.entries, logEntry{Level: -1, Msg: msg, KeysAndValues: keysAndValues, Err: err})
+}
+
+func newCaptureLogger() (logr.Logger, *captureSink) {
+	sink := &captureSink{}
+	return logr.New(sink), sink
+}
+
+func (s *captureSink) infoEntries() []logEntry {
+	var out []logEntry
+	for _, e := range s.entries {
+		if e.Level >= 0 {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+func (s *captureSink) findEntry(substr string) *logEntry {
+	for i := range s.entries {
+		if strings.Contains(s.entries[i].Msg, substr) {
+			return &s.entries[i]
+		}
+	}
+	return nil
+}
+
+func kvMap(kvs []any) map[string]any {
+	m := make(map[string]any, len(kvs)/2)
+	for i := 0; i+1 < len(kvs); i += 2 {
+		if k, ok := kvs[i].(string); ok {
+			m[k] = kvs[i+1]
+		}
+	}
+	return m
+}
+
+func testReq() ctrl.Request {
+	return ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "obj"}}
+}
+
+// ---------------------------------------------------------------------------
+// Condition Transition Tests
+// ---------------------------------------------------------------------------
+
+func TestLogConditionTransitions(t *testing.T) {
+	req := testReq()
+
+	t.Run("no prior conditions -> setStatusProgressing logs new conditions", func(t *testing.T) {
+		log, sink := newCaptureLogger()
+		var conditions []metav1.Condition
+
+		setStatusProgressing(log, req, "Engine", &conditions, 1, "Reconciling", "starting")
+
+		infos := sink.infoEntries()
+		require.NotEmpty(t, infos, "expected Info log for new conditions")
+
+		readySet := sink.findEntry("Condition set")
+		require.NotNil(t, readySet, "expected 'Condition set' for Ready=False")
+	})
+
+	t.Run("idempotent call does not log transitions", func(t *testing.T) {
+		log, sink := newCaptureLogger()
+		conditions := []metav1.Condition{
+			{Type: "Ready", Status: metav1.ConditionTrue, Reason: "RulesCached"},
+		}
+
+		setStatusReady(log, req, "RuleSet", &conditions, 1, "RulesCached", "cached")
+
+		for _, e := range sink.entries {
+			assert.NotContains(t, e.Msg, "Condition changed")
+			assert.NotContains(t, e.Msg, "Condition set")
+		}
+	})
+
+	t.Run("message-only update same status and reason stays silent", func(t *testing.T) {
+		log, sink := newCaptureLogger()
+		conditions := []metav1.Condition{
+			{Type: "Ready", Status: metav1.ConditionTrue, Reason: "Configured", Message: "old detail"},
+		}
+
+		setStatusReady(log, req, "Engine", &conditions, 1, "Configured", "new detail")
+
+		assert.Empty(t, sink.infoEntries(), "Status+Reason unchanged: no Info noise")
+	})
+
+	t.Run("Progressing -> Ready logs Ready change and Progressing removal", func(t *testing.T) {
+		log, sink := newCaptureLogger()
+		conditions := []metav1.Condition{
+			{Type: "Ready", Status: metav1.ConditionFalse, Reason: "Reconciling"},
+			{Type: "Progressing", Status: metav1.ConditionTrue, Reason: "Reconciling"},
+		}
+
+		setStatusReady(log, req, "Engine", &conditions, 1, "Configured", "done")
+
+		changedEntry := sink.findEntry("Condition changed")
+		require.NotNil(t, changedEntry)
+		kv := kvMap(changedEntry.KeysAndValues)
+		assert.Equal(t, "Ready", kv["condition"])
+		assert.Equal(t, "False", kv["fromStatus"])
+		assert.Equal(t, "True", kv["toStatus"])
+
+		removedEntry := sink.findEntry("Condition removed")
+		require.NotNil(t, removedEntry)
+		rkv := kvMap(removedEntry.KeysAndValues)
+		assert.Equal(t, "Progressing", rkv["condition"])
+	})
+
+	t.Run("Ready -> Degraded logs transitions", func(t *testing.T) {
+		log, sink := newCaptureLogger()
+		conditions := []metav1.Condition{
+			{Type: "Ready", Status: metav1.ConditionTrue, Reason: "Configured"},
+		}
+
+		setStatusConditionDegraded(log, req, "Engine", &conditions, 1, "Error", "something broke")
+
+		infos := sink.infoEntries()
+		require.GreaterOrEqual(t, len(infos), 2, "expect Ready change + Degraded set")
+
+		readyChanged := sink.findEntry("Condition changed")
+		require.NotNil(t, readyChanged)
+		rkv := kvMap(readyChanged.KeysAndValues)
+		assert.Equal(t, "Ready", rkv["condition"])
+		assert.Equal(t, "True", rkv["fromStatus"])
+		assert.Equal(t, "False", rkv["toStatus"])
+	})
+
+	t.Run("same status different reason still logs", func(t *testing.T) {
+		log, sink := newCaptureLogger()
+		conditions := []metav1.Condition{
+			{Type: "Ready", Status: metav1.ConditionFalse, Reason: "OldReason"},
+			{Type: "Degraded", Status: metav1.ConditionTrue, Reason: "OldReason"},
+		}
+
+		setStatusConditionDegraded(log, req, "RuleSet", &conditions, 1, "NewReason", "updated")
+
+		entry := sink.findEntry("Condition changed")
+		require.NotNil(t, entry, "reason-only change should log")
+		kv := kvMap(entry.KeysAndValues)
+		assert.Equal(t, "NewReason", kv["reason"])
+	})
+
+	t.Run("setStatusProgressing adds Progressing when absent", func(t *testing.T) {
+		log, sink := newCaptureLogger()
+		conditions := []metav1.Condition{
+			{Type: "Ready", Status: metav1.ConditionFalse, Reason: "Error"},
+			{Type: "Degraded", Status: metav1.ConditionTrue, Reason: "Error"},
+		}
+
+		setStatusProgressing(log, req, "RuleSet", &conditions, 2, "Retrying", "retry")
+
+		progressingSet := sink.findEntry("Condition set")
+		require.NotNil(t, progressingSet)
+		kv := kvMap(progressingSet.KeysAndValues)
+		assert.Equal(t, "Progressing", kv["condition"])
+
+		// Ready reason changes from Error to Retrying
+		readyChanged := sink.findEntry("Condition changed")
+		require.NotNil(t, readyChanged)
+		rkv := kvMap(readyChanged.KeysAndValues)
+		assert.Equal(t, "Ready", rkv["condition"])
+		assert.Equal(t, "Retrying", rkv["reason"])
+	})
+}
+
+// ---------------------------------------------------------------------------
+// extractStatusErrorFields Tests
+// ---------------------------------------------------------------------------
+
+func TestExtractStatusErrorFields(t *testing.T) {
+	t.Run("non-StatusError returns nil", func(t *testing.T) {
+		fields := extractStatusErrorFields(fmt.Errorf("plain error"))
+		assert.Nil(t, fields)
+	})
+
+	t.Run("StatusError returns code and reason", func(t *testing.T) {
+		err := apierrors.NewNotFound(
+			schema.GroupResource{Group: "waf.k8s.coraza.io", Resource: "engines"}, "my-engine")
+
+		fields := extractStatusErrorFields(err)
+		require.NotNil(t, fields)
+		kv := kvMap(fields)
+		assert.Equal(t, int32(http.StatusNotFound), kv["apiStatusCode"])
+		assert.Equal(t, string(metav1.StatusReasonNotFound), kv["apiReason"])
+	})
+
+	t.Run("wrapped StatusError is detected", func(t *testing.T) {
+		inner := apierrors.NewConflict(
+			schema.GroupResource{Resource: "engines"}, "my-engine", fmt.Errorf("conflict"))
+		wrapped := fmt.Errorf("fetching engine: %w", inner)
+
+		fields := extractStatusErrorFields(wrapped)
+		require.NotNil(t, fields)
+		kv := kvMap(fields)
+		assert.Equal(t, int32(http.StatusConflict), kv["apiStatusCode"])
+	})
+
+	t.Run("StatusError with RetryAfterSeconds includes field", func(t *testing.T) {
+		err := &apierrors.StatusError{
+			ErrStatus: metav1.Status{
+				Status:  metav1.StatusFailure,
+				Code:    http.StatusTooManyRequests,
+				Reason:  metav1.StatusReasonTooManyRequests,
+				Details: &metav1.StatusDetails{RetryAfterSeconds: 30},
+			},
+		}
+
+		fields := extractStatusErrorFields(err)
+		kv := kvMap(fields)
+		assert.Equal(t, int32(30), kv["retryAfterSeconds"])
+		assert.Equal(t, int32(http.StatusTooManyRequests), kv["apiStatusCode"])
+	})
+
+	t.Run("StatusError without RetryAfterSeconds omits field", func(t *testing.T) {
+		err := apierrors.NewInternalError(fmt.Errorf("internal"))
+
+		fields := extractStatusErrorFields(err)
+		kv := kvMap(fields)
+		_, hasRetry := kv["retryAfterSeconds"]
+		assert.False(t, hasRetry)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// logAPIError Tests
+// ---------------------------------------------------------------------------
+
+func TestLogAPIError(t *testing.T) {
+	req := testReq()
+
+	t.Run("nil obj omits resourceVersion", func(t *testing.T) {
+		log, sink := newCaptureLogger()
+		logAPIError(log, req, "Engine", fmt.Errorf("test"), "Failed to get", nil)
+
+		require.Len(t, sink.entries, 1)
+		kv := kvMap(sink.entries[0].KeysAndValues)
+		_, hasRV := kv["resourceVersion"]
+		assert.False(t, hasRV)
+	})
+
+	t.Run("obj with resourceVersion adds it", func(t *testing.T) {
+		log, sink := newCaptureLogger()
+
+		obj := &unstructured.Unstructured{}
+		obj.SetResourceVersion("12345")
+
+		err := apierrors.NewNotFound(schema.GroupResource{Resource: "engines"}, "eng")
+		logAPIError(log, req, "Engine", err, "Failed to get", obj)
+
+		require.Len(t, sink.entries, 1)
+		kv := kvMap(sink.entries[0].KeysAndValues)
+		assert.Equal(t, "12345", kv["resourceVersion"])
+		assert.Equal(t, int32(http.StatusNotFound), kv["apiStatusCode"])
+	})
+
+	t.Run("non-nil obj with empty resourceVersion omits key", func(t *testing.T) {
+		log, sink := newCaptureLogger()
+		obj := &unstructured.Unstructured{}
+		obj.SetName("x")
+
+		err := apierrors.NewTimeoutError("slow", 0)
+		logAPIError(log, req, "Engine", err, "Failed", obj)
+
+		kv := kvMap(sink.entries[0].KeysAndValues)
+		_, hasRV := kv["resourceVersion"]
+		assert.False(t, hasRV)
+	})
+
+	t.Run("extra key-value pairs are included", func(t *testing.T) {
+		log, sink := newCaptureLogger()
+		logAPIError(log, req, "RuleSet", fmt.Errorf("err"), "oops", nil, "secretName", "my-secret")
+
+		require.Len(t, sink.entries, 1)
+		kv := kvMap(sink.entries[0].KeysAndValues)
+		assert.Equal(t, "my-secret", kv["secretName"])
+	})
+}


### PR DESCRIPTION
## Summary

- Log condition transitions (Ready, Degraded, Progressing) at **Info** level only when Status or Reason actually changes, replacing the unconditional debug-level "Setting … status" messages. Idempotent no-ops are silent.
- Add `logAPIError` helper that enriches Kubernetes API error logs with `resourceVersion`, HTTP status code, `apiReason`, and `retryAfterSeconds` (when the error wraps `*apierrors.StatusError`).
- Migrate all API-facing `logError` call sites across engine and ruleset controllers to use `logAPIError`.
- Document that workqueue retry/attempt count is not available inside `Reconcile` without a cross-cutting wrapper (noted in code comment for follow-up).

Closes #262

## Test plan

- [x] `go vet ./internal/controller/...` passes
- [x] New unit tests cover: condition transition detection (new, changed, removed, idempotent), `extractStatusErrorFields` (plain error, NotFound, wrapped, RetryAfterSeconds), `logAPIError` (nil obj, obj with RV, extra kv pairs)
- [ ] CI lint/build/test

Made with [Cursor](https://cursor.com)