### PR TITLE
fix: propagate logger via context in cache server and Istio prerequisites

### DIFF
--- a/internal/controller/engine_controller_istio_prerequisites.go
+++ b/internal/controller/engine_controller_istio_prerequisites.go
@@ -26,8 +26,8 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // -----------------------------------------------------------------------------
@@ -62,7 +62,7 @@ func NewIstioPrerequisites(c client.Client, reader client.Reader, operatorName, 
 // Start applies the Istio ServiceEntry and DestinationRule for the
 // RuleSet cache server. It satisfies the manager.Runnable interface.
 func (p *IstioPrerequisites) Start(ctx context.Context) error {
-	log := ctrl.Log.WithName("istio-prerequisites")
+	log := logf.FromContext(ctx).WithName("istio-prerequisites")
 
 	if err := p.apply(ctx, log); err != nil {
 		log.Error(err, "Failed to apply Istio prerequisites (controllers will continue without them)")

--- a/internal/controller/engine_controller_istio_prerequisites_test.go
+++ b/internal/controller/engine_controller_istio_prerequisites_test.go
@@ -21,6 +21,9 @@ import (
 	"fmt"
 	"testing"
 
+	"strings"
+
+	"github.com/go-logr/logr"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -31,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 func TestBuildServiceEntry_Shape(t *testing.T) {
@@ -224,6 +228,38 @@ func TestIstioPrerequisites_StartReturnsNilOnError(t *testing.T) {
 	p := NewIstioPrerequisites(k8sClient, k8sClient, "no-such-deploy", namespace, "")
 	err := p.Start(ctx)
 	assert.NoError(t, err, "Start() must return nil even when apply fails")
+}
+
+// captureMsgSink records Info/Error messages for assertions.
+type captureMsgSink struct {
+	msgs []string
+}
+
+func (c *captureMsgSink) Init(logr.RuntimeInfo) {}
+func (c *captureMsgSink) Enabled(int) bool      { return true }
+func (c *captureMsgSink) Info(_ int, msg string, _ ...any) {
+	c.msgs = append(c.msgs, msg)
+}
+func (c *captureMsgSink) Error(_ error, msg string, _ ...any) {
+	c.msgs = append(c.msgs, msg)
+}
+func (c *captureMsgSink) WithValues(...any) logr.LogSink { return c }
+func (c *captureMsgSink) WithName(string) logr.LogSink   { return c }
+
+func TestIstioPrerequisites_StartUsesLoggerFromContext(t *testing.T) {
+	ctx := context.Background()
+	namespace := setupTestNamespace(t, ctx)
+	createDeployment(t, ctx, "test-op-ctxlog", namespace)
+
+	sink := &captureMsgSink{}
+	ctx = logf.IntoContext(ctx, logr.New(sink))
+
+	p := NewIstioPrerequisites(k8sClient, k8sClient, "test-op-ctxlog", namespace, "")
+	require.NoError(t, p.Start(ctx))
+
+	joined := strings.Join(sink.msgs, ";")
+	assert.Contains(t, joined, "Applying ServiceEntry")
+	assert.Contains(t, joined, "Applying DestinationRule")
 }
 
 // -----------------------------------------------------------------------------

--- a/internal/rulesets/cache/server.go
+++ b/internal/rulesets/cache/server.go
@@ -19,9 +19,12 @@ package cache
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"strings"
 	"time"
@@ -89,6 +92,15 @@ type ruleSetCacheServer struct {
 	gc     GarbageCollectionConfig
 }
 
+// loggerFromContext returns the logr.Logger from ctx if present,
+// otherwise returns the provided fallback logger.
+func loggerFromContext(ctx context.Context, fallback logr.Logger) logr.Logger {
+	if l, err := logr.FromContext(ctx); err == nil {
+		return l
+	}
+	return fallback
+}
+
 // NewServer creates a new RuleSetCacheServer instance.
 // The tokenReview client is used to validate ServiceAccount JWT tokens on incoming requests.
 func NewServer(cache *RuleSetCache, addr string, logger logr.Logger, gc *GarbageCollectionConfig, tokenReview authclient.TokenReviewInterface) *ruleSetCacheServer {
@@ -105,7 +117,7 @@ func NewServer(cache *RuleSetCache, addr string, logger logr.Logger, gc *Garbage
 	}
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("/rules/", s.handleRules)
+	mux.Handle("/rules/", s.withRequestLogger(http.HandlerFunc(s.handleRules)))
 
 	s.srv = &http.Server{
 		Addr:              addr,
@@ -122,29 +134,36 @@ func NewServer(cache *RuleSetCache, addr string, logger logr.Logger, gc *Garbage
 
 // Start the cache server and the GC loop. Both are stopped when ctx is cancelled.
 func (s *ruleSetCacheServer) Start(ctx context.Context) error {
+	log := loggerFromContext(ctx, s.logger).WithName("ruleset-cache")
+
+	ln, err := net.Listen("tcp", s.srv.Addr)
+	if err != nil {
+		return fmt.Errorf("cache server listen: %w", err)
+	}
+
 	go s.rungc(ctx)
 
 	errChan := make(chan error, 1)
 	go func() {
-		s.logger.Info("Starting ruleset cache server", "addr", s.srv.Addr)
-		if err := s.srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		log.Info("Starting ruleset cache server", "addr", s.srv.Addr)
+		if err := s.srv.Serve(ln); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			errChan <- err
 		}
 	}()
 
 	select {
 	case <-ctx.Done():
-		s.logger.Info("Shutting down ruleset cache server")
+		log.Info("Shutting down ruleset cache server")
 		s.srv.SetKeepAlivesEnabled(false)
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), GracefulShutdownTimeout)
 		defer cancel()
 
 		if err := s.srv.Shutdown(shutdownCtx); err != nil {
-			s.logger.Error(err, "Error during graceful shutdown, forcing close")
+			log.Error(err, "Error during graceful shutdown, forcing close")
 			return s.srv.Close()
 		}
 
-		s.logger.Info("Cache server shutdown complete")
+		log.Info("Cache server shutdown complete")
 		return nil
 	case err := <-errChan:
 		return err
@@ -154,6 +173,28 @@ func (s *ruleSetCacheServer) Start(ctx context.Context) error {
 // NeedLeaderElection implements the LeaderElectionRunnable interface.
 func (s *ruleSetCacheServer) NeedLeaderElection() bool {
 	return false
+}
+
+// -----------------------------------------------------------------------------
+// RuleSetCacheServer - Request Logging Middleware
+// -----------------------------------------------------------------------------
+
+func (s *ruleSetCacheServer) withRequestLogger(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reqID := r.Header.Get("X-Request-ID")
+		if reqID == "" {
+			reqID = shortID()
+		}
+		reqLog := loggerFromContext(r.Context(), s.logger).WithValues("requestID", reqID)
+		r = r.WithContext(logr.NewContext(r.Context(), reqLog))
+		next.ServeHTTP(w, r)
+	})
+}
+
+func shortID() string {
+	b := make([]byte, 8)
+	_, _ = rand.Read(b)
+	return hex.EncodeToString(b)
 }
 
 // -----------------------------------------------------------------------------
@@ -185,7 +226,7 @@ func (s *ruleSetCacheServer) handleRules(w http.ResponseWriter, r *http.Request)
 	// Authenticate: the token audience must match the requested RuleSet, and
 	// the SA namespace must match the cache key namespace.
 	if err := s.authenticateRequest(r, cacheKey); err != nil {
-		s.logger.Info("Authentication failed", "cacheKey", cacheKey, "error", err)
+		loggerFromContext(r.Context(), s.logger).Info("Authentication failed", "cacheKey", cacheKey, "error", err)
 		http.Error(w, "Forbidden", http.StatusForbidden)
 		return
 	}
@@ -236,7 +277,9 @@ func extractBearerToken(r *http.Request) string {
 	return ""
 }
 
-func (s *ruleSetCacheServer) handleLatest(w http.ResponseWriter, _ *http.Request, cacheKey string) {
+func (s *ruleSetCacheServer) handleLatest(w http.ResponseWriter, r *http.Request, cacheKey string) {
+	log := loggerFromContext(r.Context(), s.logger)
+
 	entry, ok := s.cache.Get(cacheKey)
 	if !ok {
 		http.Error(w, "RuleSet not found", http.StatusNotFound)
@@ -250,7 +293,7 @@ func (s *ruleSetCacheServer) handleLatest(w http.ResponseWriter, _ *http.Request
 
 	var buf bytes.Buffer
 	if err := json.NewEncoder(&buf).Encode(response); err != nil {
-		s.logger.Error(err, "Failed to encode latest response")
+		log.Error(err, "Failed to encode latest response")
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
 		return
 	}
@@ -259,18 +302,20 @@ func (s *ruleSetCacheServer) handleLatest(w http.ResponseWriter, _ *http.Request
 	_, _ = w.Write(buf.Bytes())
 }
 
-func (s *ruleSetCacheServer) handleGetRules(w http.ResponseWriter, _ *http.Request, cacheKey string) {
+func (s *ruleSetCacheServer) handleGetRules(w http.ResponseWriter, r *http.Request, cacheKey string) {
+	log := loggerFromContext(r.Context(), s.logger)
+
 	entry, ok := s.cache.Get(cacheKey)
 	if !ok {
 		http.Error(w, "RuleSet not found", http.StatusNotFound)
 		return
 	}
 
-	s.logger.Info("Serving rules from cache", "cacheKey", cacheKey, "uuid", entry.UUID, "availableKeysCount", s.cache.Len(), "cacheSizeBytes", s.cache.TotalSize())
+	log.V(1).Info("Serving rules from cache", "cacheKey", cacheKey, "uuid", entry.UUID, "availableKeysCount", s.cache.Len(), "cacheSizeBytes", s.cache.TotalSize())
 
 	var buf bytes.Buffer
 	if err := json.NewEncoder(&buf).Encode(entry); err != nil {
-		s.logger.Error(err, "Failed to encode rules response")
+		log.Error(err, "Failed to encode rules response")
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
 		return
 	}
@@ -308,6 +353,8 @@ func DefaultGC() GarbageCollectionConfig {
 // 1. Age-based: entries older than MaxAge (except latest)
 // 2. Size-based: oldest entries when cache exceeds MaxSize (except latest)
 func (s *ruleSetCacheServer) rungc(ctx context.Context) {
+	log := loggerFromContext(ctx, s.logger).WithName("ruleset-cache-gc")
+
 	ticker := time.NewTicker(s.gc.GCInterval)
 	defer ticker.Stop()
 
@@ -319,7 +366,7 @@ func (s *ruleSetCacheServer) rungc(ctx context.Context) {
 			prunedByAge := s.cache.Prune(s.gc.MaxAge)
 			if prunedByAge > 0 {
 				gcPrunedEntriesTotal.WithLabelValues(PruneReasonAge).Add(float64(prunedByAge))
-				s.logger.Info("Pruned stale cache entries by age", "count", prunedByAge, "maxAge", s.gc.MaxAge)
+				log.Info("Pruned stale cache entries by age", "count", prunedByAge, "maxAge", s.gc.MaxAge)
 			}
 
 			currentSize := s.cache.TotalSize()
@@ -327,13 +374,13 @@ func (s *ruleSetCacheServer) rungc(ctx context.Context) {
 				prunedBySize := s.cache.PruneBySize(s.gc.MaxSize)
 				if prunedBySize > 0 {
 					gcPrunedEntriesTotal.WithLabelValues(PruneReasonSize).Add(float64(prunedBySize))
-					s.logger.Info("Pruned cache entries by size", "count", prunedBySize, "maxSize", s.gc.MaxSize, "currentSize", s.cache.TotalSize())
+					log.Info("Pruned cache entries by size", "count", prunedBySize, "maxSize", s.gc.MaxSize, "currentSize", s.cache.TotalSize())
 				}
 
 				finalSize := s.cache.TotalSize()
 				if finalSize > s.gc.MaxSize {
 					gcSizeLimitExceededTotal.WithLabelValues().Inc()
-					s.logger.Error(errors.New("cache size exceeds maximum"), "CRITICAL: Cache size exceeds maximum even after pruning - latest entry is too large", "currentSize", finalSize, "maxSize", s.gc.MaxSize, "overage", finalSize-s.gc.MaxSize)
+					log.Error(errors.New("cache size exceeds maximum"), "CRITICAL: Cache size exceeds maximum even after pruning - latest entry is too large", "currentSize", finalSize, "maxSize", s.gc.MaxSize, "overage", finalSize-s.gc.MaxSize)
 				}
 			}
 		}

--- a/internal/rulesets/cache/server_logging_test.go
+++ b/internal/rulesets/cache/server_logging_test.go
@@ -18,10 +18,12 @@ package cache
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/go-logr/logr/funcr"
@@ -158,4 +160,83 @@ func TestWithRequestLogger_FromContextLoggerWithoutRequestID(t *testing.T) {
 	assert.Contains(t, joined, "suite")
 	assert.Contains(t, joined, "qa")
 	assert.Contains(t, joined, "requestID")
+}
+
+// TestWithRequestLogger_WhitespaceRequestIDIsForwardedVerbatim documents that a
+// whitespace-only X-Request-ID is treated as present (not regenerated). Product
+// may later trim; this locks current behavior for reviewers.
+func TestWithRequestLogger_WhitespaceRequestIDIsForwardedVerbatim(t *testing.T) {
+	cache := NewRuleSetCache()
+	var lines []string
+	server := NewServer(cache, ":0", captureLogger(&lines), nil, newNoopTokenReview())
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		log := loggerFromContext(r.Context(), server.logger)
+		log.Info("inner")
+		w.WriteHeader(http.StatusOK)
+	})
+
+	h := server.withRequestLogger(inner)
+	req := httptest.NewRequest(http.MethodGet, "/rules/x", nil)
+	req.Header.Set("X-Request-ID", "   \t  ")
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+	joined := strings.Join(lines, "\n")
+	assert.Contains(t, joined, "requestID")
+	assert.Contains(t, joined, "inner")
+	// funcr renders the tab from the header as a literal \t in the log line (not a rune tab).
+	assert.Contains(t, joined, "   \\t  ")
+}
+
+// TestProductionHandlerChain_AuthFailureLogsRequestID exercises the same HTTP
+// stack as production (metrics + mux + request logger + handleRules). Auth
+// failures must still correlate via requestID.
+func TestProductionHandlerChain_AuthFailureLogsRequestID(t *testing.T) {
+	cache := NewRuleSetCache()
+	var lines []string
+	s := NewServer(cache, ":0", captureLogger(&lines), nil, testTokenReview())
+
+	req := httptest.NewRequest(http.MethodGet, "http://localhost/rules/default/test-instance", nil)
+	req.Header.Set("X-Request-ID", "qa-req-auth-1")
+	rec := httptest.NewRecorder()
+	s.srv.Handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusForbidden, rec.Code)
+	joined := strings.Join(lines, "\n")
+	assert.Contains(t, joined, "qa-req-auth-1")
+	assert.Contains(t, joined, "requestID")
+	assert.Contains(t, joined, "Authentication failed")
+}
+
+// TestRuleSetCacheServer_StartUsesLoggerFromContext ensures Start/rungc resolve
+// the logger from ctx when embedded (not only the constructor fallback).
+func TestRuleSetCacheServer_StartUsesLoggerFromContext(t *testing.T) {
+	cache := NewRuleSetCache()
+	var primaryLines, fallbackLines []string
+	primaryLog := captureLogger(&primaryLines)
+	fallbackLog := captureLogger(&fallbackLines)
+	ctx, cancel := context.WithCancel(logr.NewContext(context.Background(), primaryLog))
+	s := NewServer(cache, ":0", fallbackLog, nil, newNoopTokenReview())
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- s.Start(ctx) }()
+
+	time.Sleep(200 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			require.NoError(t, err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Start did not return after cancel")
+	}
+
+	joined := strings.Join(primaryLines, "\n")
+	assert.Contains(t, joined, "Starting ruleset cache server")
+	assert.Contains(t, joined, "Shutting down ruleset cache server")
+	require.Empty(t, fallbackLines, "fallback logger must not receive logs when ctx carries a logger")
 }

--- a/internal/rulesets/cache/server_logging_test.go
+++ b/internal/rulesets/cache/server_logging_test.go
@@ -1,0 +1,161 @@
+/*
+Copyright Coraza Kubernetes Operator contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/funcr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/networking-incubator/coraza-kubernetes-operator/test/utils"
+)
+
+func captureLogger(lines *[]string) logr.Logger {
+	return funcr.New(func(prefix, args string) {
+		*lines = append(*lines, prefix+args)
+	}, funcr.Options{})
+}
+
+func TestLoggerFromContext_PrefersContextLogger(t *testing.T) {
+	var primaryLines, fallbackLines []string
+	primaryLog := captureLogger(&primaryLines)
+	fallbackLog := captureLogger(&fallbackLines)
+	ctx := logr.NewContext(context.Background(), primaryLog)
+
+	got := loggerFromContext(ctx, fallbackLog)
+	got.Info("probe")
+
+	require.NotEmpty(t, primaryLines)
+	assert.Empty(t, fallbackLines)
+}
+
+func TestLoggerFromContext_FallsBackWhenNoLoggerInContext(t *testing.T) {
+	var fallbackLines []string
+	fallbackLog := captureLogger(&fallbackLines)
+
+	got := loggerFromContext(context.Background(), fallbackLog)
+	got.Info("probe")
+
+	require.NotEmpty(t, fallbackLines)
+}
+
+func TestShortID_IsHexSixteenChars(t *testing.T) {
+	id := shortID()
+	assert.Len(t, id, 16)
+	for _, c := range id {
+		assert.True(t, (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'), "got %q", id)
+	}
+}
+
+func TestWithRequestLogger_ForwardsXRequestID(t *testing.T) {
+	cache := NewRuleSetCache()
+	var lines []string
+	server := NewServer(cache, ":0", captureLogger(&lines), nil, newNoopTokenReview())
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		log := loggerFromContext(r.Context(), server.logger)
+		log.Info("inner")
+		w.WriteHeader(http.StatusOK)
+	})
+
+	h := server.withRequestLogger(inner)
+	req := httptest.NewRequest(http.MethodGet, "/rules/x", nil)
+	req.Header.Set("X-Request-ID", "upstream-req-99")
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+	joined := strings.Join(lines, "\n")
+	assert.Contains(t, joined, "upstream-req-99")
+	assert.Contains(t, joined, "inner")
+}
+
+func TestWithRequestLogger_EmptyXRequestIDGeneratesID(t *testing.T) {
+	cache := NewRuleSetCache()
+	var lines []string
+	server := NewServer(cache, ":0", captureLogger(&lines), nil, newNoopTokenReview())
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		log := loggerFromContext(r.Context(), server.logger)
+		log.Info("inner")
+		w.WriteHeader(http.StatusOK)
+	})
+
+	h := server.withRequestLogger(inner)
+	req := httptest.NewRequest(http.MethodGet, "/rules/x", nil)
+	req.Header.Set("X-Request-ID", "")
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+	joined := strings.Join(lines, "\n")
+	assert.Contains(t, joined, "requestID")
+	foundHex := false
+	for i := 0; i+15 < len(joined); i++ {
+		chunk := joined[i : i+16]
+		if isLowerHex(chunk) {
+			foundHex = true
+			break
+		}
+	}
+	assert.True(t, foundHex, "expected 16-char hex id in log: %q", joined)
+}
+
+func isLowerHex(s string) bool {
+	if len(s) != 16 {
+		return false
+	}
+	for _, c := range s {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+			return false
+		}
+	}
+	return true
+}
+
+func TestWithRequestLogger_FromContextLoggerWithoutRequestID(t *testing.T) {
+	cache := NewRuleSetCache()
+	var lines []string
+	base := captureLogger(&lines)
+	ctx := logr.NewContext(context.Background(), base.WithValues("suite", "qa"))
+	server := NewServer(cache, ":0", utils.NewTestLogger(t), nil, newNoopTokenReview())
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		log := loggerFromContext(r.Context(), server.logger)
+		log.Info("inner")
+		w.WriteHeader(http.StatusOK)
+	})
+
+	h := server.withRequestLogger(inner)
+	req := httptest.NewRequest(http.MethodGet, "/rules/x", nil)
+	req = req.WithContext(ctx)
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+	joined := strings.Join(lines, "\n")
+	assert.Contains(t, joined, "suite")
+	assert.Contains(t, joined, "qa")
+	assert.Contains(t, joined, "requestID")
+}


### PR DESCRIPTION
## Summary

- **IstioPrerequisites.Start**: replaced `ctrl.Log.WithName(...)` with `logf.FromContext(ctx).WithName(...)` to derive the logger from the runnable context instead of the package-level global.
- **Cache server**: added a `loggerFromContext` helper that tries `logr.FromContext(ctx)` and falls back to the injected `s.logger`, keeping existing tests (which use `context.Background()`) working without changes.
- **Start/rungc**: resolve logger from ctx at entry point.
- **HTTP handlers**: new `withRequestLogger` middleware injects a per-request logger carrying `X-Request-ID` (forwarded from the client header or generated) into the request context. Handlers read the logger from `r.Context()`.
- **Log volume**: moved the per-request "Serving rules from cache" log to `V(1)` to reduce noise at scale.

No changes to `NewServer` signature or `cmd/manager/main.go` — the fallback logger passed at construction remains `ctrl.Log` in production.

Closes #53

## Test plan

- [ ] Existing unit tests for cache server pass unchanged (handlers call `handleRules` directly, bypassing middleware — fallback to `s.logger` works)
- [ ] Existing `IstioPrerequisites` tests pass (most call `apply()` directly with an explicit logger; `Start()` test uses `context.Background()` which falls back to global)
- [ ] `TestServer_StartAndStop` / GC tests continue working (context without logger → fallback)
- [ ] When middleware is in the path (production), `X-Request-ID` appears in log output for handler-level logs


Made with [Cursor](https://cursor.com)