### PR TITLE
feat: exclude WASM-unsupported rules from kubectl-coraza generate by default

### DIFF
--- a/cmd/kubectl-coraza/README.md
+++ b/cmd/kubectl-coraza/README.md
@@ -35,6 +35,7 @@ Reads `*.conf` and optional `*.data` from a single directory (non-recursive). Ou
 | `--ruleset-name` | RuleSet name (default `default-ruleset`) |
 | `--data-secret-name` | Secret name for `*.data` (default `coreruleset-data`) |
 | `--ignore-rules` | Comma-separated rule IDs to drop |
+| `--include-wasm-unsupported-rules` | Include rules the operator's WASM engine cannot process (default `false`; see `LIMITATIONS.md`) |
 | `--ignore-pmFromFile` | Strip `SecRule` lines using `@pmFromFile` |
 | `--include-test-rule` | Append X-CRS-Test block to `base-rules` |
 | `--name-prefix` / `--name-suffix` | Prefix/suffix for ConfigMap names |

--- a/cmd/kubectl-coraza/main.go
+++ b/cmd/kubectl-coraza/main.go
@@ -82,6 +82,7 @@ need metadata.namespace on every object.`,
 	flags.String("name-suffix", "", "optional suffix for ConfigMap names derived from *.conf filenames")
 	flags.String("dry-run", "", "if set to client, print the same manifests and annotate stderr (no cluster access is performed either way)")
 	flags.Bool("skip-size-check", false, "allow very large rules payloads (not recommended; etcd limits may still reject applies)")
+	flags.Bool("include-wasm-unsupported-rules", false, "include rules the operator's WASM engine cannot process (by default these are excluded; see LIMITATIONS.md)")
 
 	root.AddCommand(generate)
 	generate.AddCommand(coreruleset)
@@ -110,6 +111,7 @@ func genCRS(cmd *cobra.Command, _ []string) error {
 	nameSuffix, _ := flags.GetString("name-suffix")
 	dry, _ := flags.GetString("dry-run")
 	skipSize, _ := flags.GetBool("skip-size-check")
+	includeWASMUnsupported, _ := flags.GetBool("include-wasm-unsupported-rules")
 
 	ignoreSet := map[string]struct{}{}
 	if strings.TrimSpace(ignoreCSV) != "" {
@@ -130,19 +132,20 @@ func genCRS(cmd *cobra.Command, _ []string) error {
 	}
 
 	opts := corerulesetgen.Options{
-		RulesDir:         rulesDir,
-		Version:          ver,
-		IgnoreRuleIDs:    ignoreSet,
-		IgnorePMFromFile: ignorePM,
-		IncludeTestRule:  includeTest,
-		RuleSetName:      rulesetName,
-		Namespace:        namespace,
-		DataSecretName:   dataSecret,
-		NamePrefix:       namePrefix,
-		NameSuffix:       nameSuffix,
-		DryRun:           strings.EqualFold(strings.TrimSpace(dry), "client"),
-		SkipSizeCheck:    skipSize,
-		Stderr:           cmd.ErrOrStderr(),
+		RulesDir:                    rulesDir,
+		Version:                     ver,
+		IgnoreRuleIDs:               ignoreSet,
+		IgnorePMFromFile:            ignorePM,
+		IncludeTestRule:             includeTest,
+		RuleSetName:                 rulesetName,
+		Namespace:                   namespace,
+		DataSecretName:              dataSecret,
+		NamePrefix:                  namePrefix,
+		NameSuffix:                  nameSuffix,
+		DryRun:                      strings.EqualFold(strings.TrimSpace(dry), "client"),
+		SkipSizeCheck:               skipSize,
+		IncludeWASMUnsupportedRules: includeWASMUnsupported,
+		Stderr:                      cmd.ErrOrStderr(),
 	}
 
 	_, err := corerulesetgen.Generate(cmd.OutOrStdout(), opts)

--- a/cmd/kubectl-coraza/main_test.go
+++ b/cmd/kubectl-coraza/main_test.go
@@ -188,6 +188,36 @@ func TestGenCRS_withDataSecret(t *testing.T) {
 	assert.Contains(t, stdout.String(), "kind: RuleSet")
 }
 
+func TestGenCRS_excludesWASMUnsupportedByDefault(t *testing.T) {
+	dir := t.TempDir()
+	confPath := filepath.Join(dir, "unsup.conf")
+	require.NoError(t, os.WriteFile(confPath, []byte(
+		"SecRule ARGS \"@rx a\" \"id:922110,phase:2,pass,nolog\"\n"+
+			"SecRule ARGS \"@rx b\" \"id:42,phase:2,pass,nolog\"\n"), 0o644))
+
+	cmd, stdout, _ := newTestCommand(t)
+	cmd.SetArgs([]string{"generate", "coreruleset", "--rules-dir", dir, "--version", "4.24.1"})
+
+	require.NoError(t, cmd.Execute())
+	assert.NotContains(t, stdout.String(), "id:922110,")
+	assert.Contains(t, stdout.String(), "id:42,")
+}
+
+func TestGenCRS_includeWASMUnsupportedFlag(t *testing.T) {
+	dir := t.TempDir()
+	confPath := filepath.Join(dir, "unsup.conf")
+	require.NoError(t, os.WriteFile(confPath, []byte(
+		"SecRule ARGS \"@rx a\" \"id:922110,phase:2,pass,nolog\"\n"+
+			"SecRule ARGS \"@rx b\" \"id:42,phase:2,pass,nolog\"\n"), 0o644))
+
+	cmd, stdout, _ := newTestCommand(t)
+	cmd.SetArgs([]string{"generate", "coreruleset", "--rules-dir", dir, "--version", "4.24.1", "--include-wasm-unsupported-rules"})
+
+	require.NoError(t, cmd.Execute())
+	assert.Contains(t, stdout.String(), "id:922110,")
+	assert.Contains(t, stdout.String(), "id:42,")
+}
+
 func TestGenCRS_missingRequiredFlags(t *testing.T) {
 	cmd, _, _ := newTestCommand(t)
 	cmd.SetArgs([]string{"generate", "coreruleset"})
@@ -251,6 +281,7 @@ func newTestCommand(t *testing.T) (*cobra.Command, *bytes.Buffer, *bytes.Buffer)
 	flags.String("name-suffix", "", "")
 	flags.String("dry-run", "", "")
 	flags.Bool("skip-size-check", false, "")
+	flags.Bool("include-wasm-unsupported-rules", false, "")
 
 	root.AddCommand(generate)
 	generate.AddCommand(coreruleset)

--- a/internal/rulesets/unsupported.go
+++ b/internal/rulesets/unsupported.go
@@ -87,6 +87,17 @@ func RedundantRuleIDs() []int {
 	return ruleIDsByTier(TierRedundant)
 }
 
+// AllUnsupportedRuleIDs returns all registered unsupported rule IDs (both
+// incompatible and redundant tiers), sorted ascending.
+func AllUnsupportedRuleIDs() []int {
+	ids := make([]int, 0, len(unsupportedRules))
+	for id := range unsupportedRules {
+		ids = append(ids, id)
+	}
+	sort.Ints(ids)
+	return ids
+}
+
 // FormatUnsupportedMessage returns a human-readable status message for the given unsupported rules.
 func FormatUnsupportedMessage(found []UnsupportedRule) string {
 	if len(found) == 0 {

--- a/internal/rulesets/unsupported_test.go
+++ b/internal/rulesets/unsupported_test.go
@@ -36,6 +36,29 @@ func TestRegistryCompleteness(t *testing.T) {
 	assert.Equal(t, 67, total, "total unsupported rules")
 }
 
+func TestAllUnsupportedRuleIDs(t *testing.T) {
+	all := AllUnsupportedRuleIDs()
+	incompatible := IncompatibleRuleIDs()
+	redundant := RedundantRuleIDs()
+
+	assert.Len(t, all, len(incompatible)+len(redundant), "AllUnsupportedRuleIDs should return both tiers")
+
+	for i := 1; i < len(all); i++ {
+		assert.Less(t, all[i-1], all[i], "IDs should be sorted ascending")
+	}
+
+	idSet := make(map[int]bool, len(all))
+	for _, id := range all {
+		idSet[id] = true
+	}
+	for _, id := range incompatible {
+		assert.True(t, idSet[id], "incompatible ID %d should be in AllUnsupportedRuleIDs", id)
+	}
+	for _, id := range redundant {
+		assert.True(t, idSet[id], "redundant ID %d should be in AllUnsupportedRuleIDs", id)
+	}
+}
+
 func TestCheckUnsupportedRules_ResponseBodyInspection(t *testing.T) {
 	responseBodyIDs := []int{
 		950150,

--- a/tools/corerulesetgen/build.go
+++ b/tools/corerulesetgen/build.go
@@ -2,6 +2,9 @@ package corerulesetgen
 
 import (
 	"path/filepath"
+	"strconv"
+
+	"github.com/networking-incubator/coraza-kubernetes-operator/internal/rulesets"
 )
 
 // NamedYAML is one generated ConfigMap manifest (full document YAML).
@@ -38,6 +41,8 @@ type ManifestBundle struct {
 // Build produces base ConfigMap, per-.conf ConfigMaps, optional Secret, and RuleSet from a
 // parsed [CRSVersion]. It does not read stderr or write to stdout.
 func Build(opts Options, scan ScanResult, ver CRSVersion) (*ManifestBundle, error) {
+	opts = mergeWASMUnsupportedIDs(opts)
+
 	baseYAML, baseRulesScalar := baseRulesYAML(ver.Normalized, ver.Setup, opts.IncludeTestRule)
 	baseYAML = injectNamespaceInBaseConfigMapYAML(baseYAML, opts.Namespace)
 	if err := checkPayloadSize(baseRulesScalar, "base-rules", opts); err != nil {
@@ -89,4 +94,22 @@ func Build(opts Options, scan ScanResult, ver CRSVersion) (*ManifestBundle, erro
 		Stats:             BuildStats{Processed: processed, Skipped: skipped},
 		ConfFileResults:   confResults,
 	}, nil
+}
+
+// mergeWASMUnsupportedIDs returns a copy of opts with the operator's WASM
+// unsupported rule IDs merged into IgnoreRuleIDs, unless the caller opted
+// out via IncludeWASMUnsupportedRules.
+func mergeWASMUnsupportedIDs(opts Options) Options {
+	if opts.IncludeWASMUnsupportedRules {
+		return opts
+	}
+	merged := make(map[string]struct{}, len(opts.IgnoreRuleIDs)+len(rulesets.AllUnsupportedRuleIDs()))
+	for id := range opts.IgnoreRuleIDs {
+		merged[id] = struct{}{}
+	}
+	for _, id := range rulesets.AllUnsupportedRuleIDs() {
+		merged[strconv.Itoa(id)] = struct{}{}
+	}
+	opts.IgnoreRuleIDs = merged
+	return opts
 }

--- a/tools/corerulesetgen/build_test.go
+++ b/tools/corerulesetgen/build_test.go
@@ -217,6 +217,85 @@ func mustParseCRSVersion(t *testing.T, v string) CRSVersion {
 	return ver
 }
 
+func TestBuild_excludesWASMUnsupportedRulesByDefault(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "unsup.conf")
+	err := os.WriteFile(path, []byte(
+		"SecRule ARGS \"@rx a\" \"id:922110,phase:2,pass,nolog\"\n"+
+			"SecRule ARGS \"@rx b\" \"id:42,phase:2,pass,nolog\"\n"), 0o644)
+	require.NoError(t, err)
+
+	ver := mustParseCRSVersion(t, "4.24.1")
+	scan, err := Scan(tmp)
+	require.NoError(t, err)
+
+	bundle, err := Build(Options{
+		RulesDir:       tmp,
+		Version:        "4.24.1",
+		RuleSetName:    "rs",
+		DataSecretName: "ds",
+	}, scan, ver)
+	require.NoError(t, err)
+
+	require.Len(t, bundle.ExtraConfigMaps, 1)
+	require.NotContains(t, bundle.ExtraConfigMaps[0].Doc, "id:922110,")
+	require.Contains(t, bundle.ExtraConfigMaps[0].Doc, "id:42,")
+}
+
+func TestBuild_includesWASMUnsupportedRulesWhenOptedIn(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "unsup.conf")
+	err := os.WriteFile(path, []byte(
+		"SecRule ARGS \"@rx a\" \"id:922110,phase:2,pass,nolog\"\n"+
+			"SecRule ARGS \"@rx b\" \"id:42,phase:2,pass,nolog\"\n"), 0o644)
+	require.NoError(t, err)
+
+	ver := mustParseCRSVersion(t, "4.24.1")
+	scan, err := Scan(tmp)
+	require.NoError(t, err)
+
+	bundle, err := Build(Options{
+		RulesDir:                    tmp,
+		Version:                     "4.24.1",
+		RuleSetName:                 "rs",
+		DataSecretName:              "ds",
+		IncludeWASMUnsupportedRules: true,
+	}, scan, ver)
+	require.NoError(t, err)
+
+	require.Len(t, bundle.ExtraConfigMaps, 1)
+	require.Contains(t, bundle.ExtraConfigMaps[0].Doc, "id:922110,")
+	require.Contains(t, bundle.ExtraConfigMaps[0].Doc, "id:42,")
+}
+
+func TestBuild_wasmUnsupportedMergesWithUserIgnoreIDs(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "mixed.conf")
+	err := os.WriteFile(path, []byte(
+		"SecRule ARGS \"@rx a\" \"id:922110,phase:2,pass,nolog\"\n"+
+			"SecRule ARGS \"@rx b\" \"id:42,phase:2,pass,nolog\"\n"+
+			"SecRule ARGS \"@rx c\" \"id:99,phase:2,pass,nolog\"\n"), 0o644)
+	require.NoError(t, err)
+
+	ver := mustParseCRSVersion(t, "4.24.1")
+	scan, err := Scan(tmp)
+	require.NoError(t, err)
+
+	bundle, err := Build(Options{
+		RulesDir:       tmp,
+		Version:        "4.24.1",
+		RuleSetName:    "rs",
+		DataSecretName: "ds",
+		IgnoreRuleIDs:  map[string]struct{}{"42": {}},
+	}, scan, ver)
+	require.NoError(t, err)
+
+	require.Len(t, bundle.ExtraConfigMaps, 1)
+	require.NotContains(t, bundle.ExtraConfigMaps[0].Doc, "id:922110,")
+	require.NotContains(t, bundle.ExtraConfigMaps[0].Doc, "id:42,")
+	require.Contains(t, bundle.ExtraConfigMaps[0].Doc, "id:99,")
+}
+
 func TestBuild_confResultWarnsWhenIgnoringPMFromFile(t *testing.T) {
 	tmp := t.TempDir()
 	const name = "pm.conf"

--- a/tools/corerulesetgen/generate.go
+++ b/tools/corerulesetgen/generate.go
@@ -33,6 +33,13 @@ type Options struct {
 	DryRun           bool
 	SkipSizeCheck    bool
 	Stderr           io.Writer
+
+	// IncludeWASMUnsupportedRules controls whether rules from the operator's
+	// WASM-unsupported registry are kept in the output. When false (the zero
+	// value / default), those rule IDs are merged into the effective ignore
+	// set so generated manifests match what the operator accepts. Set to true
+	// to emit the full CRS without operator-side filtering.
+	IncludeWASMUnsupportedRules bool
 }
 
 // Result holds a short summary after a successful Generate.


### PR DESCRIPTION
## Summary

- Exports `AllUnsupportedRuleIDs()` from `internal/rulesets` so the WASM-unsupported rule registry is reusable outside the controller
- Adds `IncludeWASMUnsupportedRules` field to `corerulesetgen.Options` — zero value (false) merges registry IDs into the effective ignore set
- Merge logic in `Build()` unions user `--ignore-rules` with registry IDs, preserving existing chain-drop behavior
- Adds `--include-wasm-unsupported-rules` CLI flag (default `false`) for users who want the full CRS output
- Tests at all three layers: `internal/rulesets`, `tools/corerulesetgen`, `cmd/kubectl-coraza`
- Updates `cmd/kubectl-coraza/README.md` flag table

## Test plan

- [ ] `go test ./internal/rulesets/...` — `TestAllUnsupportedRuleIDs` verifies both tiers are returned sorted
- [ ] `go test ./tools/corerulesetgen/...` — three new `Build` tests: default excludes unsupported IDs, opt-in includes them, user ignore set is unioned with registry
- [ ] `go test ./cmd/kubectl-coraza/...` — two new tests: default excludes 922110, `--include-wasm-unsupported-rules` keeps it
- [ ] Existing golden tests pass unchanged (fixture rule IDs 100/200 are not in the registry)

Closes #57

Made with [Cursor](https://cursor.com)