### PR TITLE
feat: add USE-method metrics for RuleSet cache

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -39,6 +39,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -272,6 +273,9 @@ func setupCacheServer(mgr ctrl.Manager, cfg config, kubeClient *kubernetes.Clien
 		MaxAge:     cfg.cacheMaxAge,
 		MaxSize:    cfg.cacheMaxSize,
 	}
+
+	cache.RegisterUSEMetrics(metrics.Registry, rulesetCache, *gcConfig)
+
 	tokenReview := kubeClient.AuthenticationV1().TokenReviews()
 	cacheServer := cache.NewServer(rulesetCache, fmt.Sprintf(":%d", cfg.cacheServerPort), ctrl.Log, gcConfig, tokenReview)
 	if err := mgr.Add(cacheServer); err != nil {

--- a/internal/rulesets/cache/metrics_test.go
+++ b/internal/rulesets/cache/metrics_test.go
@@ -22,14 +22,26 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	"github.com/networking-incubator/coraza-kubernetes-operator/test/utils"
 )
+
+// useTestCache is the shared cache instance used by USE metric tests.
+// Registered on the global metrics.Registry in init() so GaugeFunc closures
+// read from this cache.
+var useTestCache = NewRuleSetCache()
+
+func init() {
+	RegisterUSEMetrics(metrics.Registry, useTestCache, DefaultGC())
+}
 
 func TestMetricsRegistered(t *testing.T) {
 	registry := metrics.Registry
@@ -300,6 +312,216 @@ func TestInstrumentHandler_PanicAfterWriteHeaderUsesWrittenCode(t *testing.T) {
 	}()
 	handler.ServeHTTP(httptest.NewRecorder(), req)
 	t.Fatal("expected panic")
+}
+
+// ---------------------------------------------------------------------------
+// USE metrics
+// ---------------------------------------------------------------------------
+
+func TestUSEMetricsRegistered(t *testing.T) {
+	// Populate at least one cache key so coraza_cache_entries emits a sample.
+	useTestCache.Put("use-lint/x", "rules", nil)
+
+	problems, err := testutil.GatherAndLint(metrics.Registry,
+		MetricCacheSizeBytes,
+		MetricCacheInstances,
+		MetricCacheEntries,
+		MetricCacheConfigMaxSizeBytes,
+		MetricCacheGCPrunedEntriesTotal,
+		MetricCacheGCSizeLimitExceeded,
+	)
+	require.NoError(t, err)
+	assert.Empty(t, problems, "USE metric lint problems")
+}
+
+func TestUSEMetrics_SizeBytesReflectsCache(t *testing.T) {
+	before := gatherGaugeValue(t, metrics.Registry, MetricCacheSizeBytes)
+	useTestCache.Put("use-size/a", "some rules for size test", nil)
+
+	after := gatherGaugeValue(t, metrics.Registry, MetricCacheSizeBytes)
+	assert.Greater(t, after, before, "size_bytes should increase after Put")
+}
+
+func TestUSEMetrics_InstancesReflectsCache(t *testing.T) {
+	before := gatherGaugeValue(t, metrics.Registry, MetricCacheInstances)
+	useTestCache.Put("use-instances/unique-key", "rules", nil)
+
+	after := gatherGaugeValue(t, metrics.Registry, MetricCacheInstances)
+	assert.Equal(t, before+1, after, "instances should increase by 1 after adding a new key")
+}
+
+func TestUSEMetrics_ConfigMaxSizeBytesIsConstant(t *testing.T) {
+	val := gatherGaugeValue(t, metrics.Registry, MetricCacheConfigMaxSizeBytes)
+	assert.Equal(t, float64(DefaultGC().MaxSize), val)
+}
+
+func TestUSEMetrics_CacheEntriesPerKey(t *testing.T) {
+	c := NewRuleSetCache()
+	collector := newCacheEntriesCollector(c)
+
+	c.Put("ns/foo", "v1", nil)
+	c.Put("ns/foo", "v2", nil)
+	c.Put("ns/bar", "v1", nil)
+
+	ch := make(chan prometheus.Metric, 10)
+	collector.Collect(ch)
+	close(ch)
+
+	byKey := map[string]float64{}
+	for m := range ch {
+		var d dto.Metric
+		require.NoError(t, m.Write(&d))
+		for _, lp := range d.GetLabel() {
+			if lp.GetName() == "cache_key" {
+				byKey[lp.GetValue()] = d.GetGauge().GetValue()
+			}
+		}
+	}
+	assert.Equal(t, float64(2), byKey["ns/foo"])
+	assert.Equal(t, float64(1), byKey["ns/bar"])
+}
+
+func TestUSEMetrics_CacheEntriesCollectorEmitsNoStaleKeys(t *testing.T) {
+	c := NewRuleSetCache()
+	collector := newCacheEntriesCollector(c)
+
+	c.Put("ns/temp", "rules", nil)
+	ch := make(chan prometheus.Metric, 10)
+	collector.Collect(ch)
+	close(ch)
+	assert.Len(t, drainMetrics(ch), 1, "should emit one sample for one key")
+
+	// Empty cache produces zero samples (no stale labels).
+	c2 := NewRuleSetCache()
+	collector2 := newCacheEntriesCollector(c2)
+	ch2 := make(chan prometheus.Metric, 10)
+	collector2.Collect(ch2)
+	close(ch2)
+	assert.Empty(t, drainMetrics(ch2), "empty cache should emit zero samples")
+}
+
+func TestUSEMetrics_GCPrunedByAge(t *testing.T) {
+	gcPrunedEntriesTotal.Reset()
+
+	c := NewRuleSetCache()
+	logger := utils.NewTestLogger(t)
+	gc := &GarbageCollectionConfig{
+		GCInterval: 50 * time.Millisecond,
+		MaxAge:     100 * time.Millisecond,
+		MaxSize:    1024 * 1024 * 1024,
+	}
+	srv := NewServer(c, ":0", logger, gc, newNoopTokenReview())
+
+	c.Put("ns/a", "old", nil)
+	c.Put("ns/a", "new", nil)
+	c.SetEntryTimestamp("ns/a", 0, time.Now().Add(-200*time.Millisecond))
+
+	ctx := t.Context()
+	go srv.rungc(ctx)
+	time.Sleep(150 * time.Millisecond)
+
+	val := testutil.ToFloat64(gcPrunedEntriesTotal.WithLabelValues(PruneReasonAge))
+	assert.GreaterOrEqual(t, val, float64(1), "age prune counter should increment")
+}
+
+func TestUSEMetrics_GCPrunedBySize(t *testing.T) {
+	gcPrunedEntriesTotal.Reset()
+
+	c := NewRuleSetCache()
+	logger := utils.NewTestLogger(t)
+	gc := &GarbageCollectionConfig{
+		GCInterval: 50 * time.Millisecond,
+		MaxAge:     24 * time.Hour,
+		MaxSize:    10,
+	}
+	srv := NewServer(c, ":0", logger, gc, newNoopTokenReview())
+
+	c.Put("ns/a", "old version with enough bytes", nil)
+	c.Put("ns/a", "new version", nil)
+
+	ctx := t.Context()
+	go srv.rungc(ctx)
+	time.Sleep(150 * time.Millisecond)
+
+	val := testutil.ToFloat64(gcPrunedEntriesTotal.WithLabelValues(PruneReasonSize))
+	assert.GreaterOrEqual(t, val, float64(1), "size prune counter should increment")
+}
+
+// Adversarial: RegisterUSEMetrics must be safe to call more than once (sync.Once; no double-register panic).
+func TestRegisterUSEMetrics_SecondCallDoesNotPanic(t *testing.T) {
+	require.NotPanics(t, func() {
+		RegisterUSEMetrics(metrics.Registry, NewRuleSetCache(), DefaultGC())
+	})
+}
+
+// Adversarial: cache_key label must tolerate non-ASCII instance paths (same class of input as HTTP paths).
+func TestUSEMetrics_CacheEntriesCollector_UnicodeCacheKey(t *testing.T) {
+	c := NewRuleSetCache()
+	collector := newCacheEntriesCollector(c)
+	key := "ns/" + string([]rune{0x540d, 0x524d})
+	c.Put(key, "rules", nil)
+
+	ch := make(chan prometheus.Metric, 10)
+	collector.Collect(ch)
+	close(ch)
+
+	var found bool
+	for _, m := range drainMetrics(ch) {
+		var d dto.Metric
+		require.NoError(t, m.Write(&d))
+		for _, lp := range d.GetLabel() {
+			if lp.GetName() == "cache_key" && lp.GetValue() == key {
+				found = true
+				assert.Equal(t, float64(1), d.GetGauge().GetValue())
+			}
+		}
+	}
+	assert.True(t, found, "expected a sample for unicode cache_key %q", key)
+}
+
+func TestUSEMetrics_GCSizeLimitExceeded(t *testing.T) {
+	before := testutil.ToFloat64(gcSizeLimitExceededTotal)
+
+	c := NewRuleSetCache()
+	logger := utils.NewTestLogger(t)
+	gc := &GarbageCollectionConfig{
+		GCInterval: 50 * time.Millisecond,
+		MaxAge:     24 * time.Hour,
+		MaxSize:    5,
+	}
+	srv := NewServer(c, ":0", logger, gc, newNoopTokenReview())
+
+	c.Put("ns/big", "this string is definitely longer than 5 bytes", nil)
+
+	ctx := t.Context()
+	go srv.rungc(ctx)
+	time.Sleep(150 * time.Millisecond)
+
+	after := testutil.ToFloat64(gcSizeLimitExceededTotal)
+	assert.Greater(t, after, before, "size-limit-exceeded counter should increment when latest entry exceeds MaxSize")
+}
+
+// gatherGaugeValue gathers the named gauge metric from a prometheus.Gatherer.
+func gatherGaugeValue(t *testing.T, g prometheus.Gatherer, name string) float64 {
+	t.Helper()
+	families, err := g.Gather()
+	require.NoError(t, err)
+	for _, mf := range families {
+		if mf.GetName() == name {
+			require.NotEmpty(t, mf.GetMetric(), "metric %s has no samples", name)
+			return mf.GetMetric()[0].GetGauge().GetValue()
+		}
+	}
+	t.Fatalf("metric %s not found", name)
+	return 0
+}
+
+func drainMetrics(ch <-chan prometheus.Metric) []prometheus.Metric {
+	var out []prometheus.Metric
+	for m := range ch {
+		out = append(out, m)
+	}
+	return out
 }
 
 // End-to-end: real server mux + instrumentHandler records metrics (same wiring as production).

--- a/internal/rulesets/cache/metrics_use.go
+++ b/internal/rulesets/cache/metrics_use.go
@@ -1,0 +1,119 @@
+/*
+Copyright Coraza Kubernetes Operator contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	MetricCacheSizeBytes            = "coraza_cache_size_bytes"
+	MetricCacheInstances            = "coraza_cache_instances"
+	MetricCacheEntries              = "coraza_cache_entries"
+	MetricCacheConfigMaxSizeBytes   = "coraza_cache_config_max_size_bytes"
+	MetricCacheGCPrunedEntriesTotal = "coraza_cache_gc_pruned_entries_total"
+	MetricCacheGCSizeLimitExceeded  = "coraza_cache_gc_size_limit_exceeded_total"
+)
+
+const (
+	PruneReasonAge  = "age"
+	PruneReasonSize = "size"
+)
+
+var (
+	gcPrunedEntriesTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: MetricCacheGCPrunedEntriesTotal,
+			Help: "Total number of cache entries pruned by the garbage collector.",
+		},
+		[]string{"reason"},
+	)
+
+	gcSizeLimitExceededTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: MetricCacheGCSizeLimitExceeded,
+			Help: "Total number of GC cycles where cache size still exceeded the configured maximum after pruning.",
+		},
+	)
+
+	registerOnce sync.Once
+)
+
+// cacheEntriesCollector implements prometheus.Collector to emit per-cache-key
+// entry counts on every scrape, avoiding stale label sets when keys are removed.
+type cacheEntriesCollector struct {
+	cache *RuleSetCache
+	desc  *prometheus.Desc
+}
+
+func newCacheEntriesCollector(c *RuleSetCache) *cacheEntriesCollector {
+	return &cacheEntriesCollector{
+		cache: c,
+		desc: prometheus.NewDesc(
+			MetricCacheEntries,
+			"Number of stored entry revisions per cache key.",
+			[]string{"cache_key"}, nil,
+		),
+	}
+}
+
+func (c *cacheEntriesCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.desc
+}
+
+func (c *cacheEntriesCollector) Collect(ch chan<- prometheus.Metric) {
+	for _, key := range c.cache.ListKeys() {
+		count := c.cache.CountEntries(key)
+		ch <- prometheus.MustNewConstMetric(c.desc, prometheus.GaugeValue, float64(count), key)
+	}
+}
+
+// RegisterUSEMetrics registers USE-method (Utilization/Saturation/Errors) metrics
+// for the RuleSet cache. Safe to call multiple times; registration happens at most
+// once per process via sync.Once.
+func RegisterUSEMetrics(reg prometheus.Registerer, c *RuleSetCache, gc GarbageCollectionConfig) {
+	registerOnce.Do(func() {
+		reg.MustRegister(
+			prometheus.NewGaugeFunc(
+				prometheus.GaugeOpts{
+					Name: MetricCacheSizeBytes,
+					Help: "Current total payload size of the cache in bytes.",
+				},
+				func() float64 { return float64(c.TotalSize()) },
+			),
+			prometheus.NewGaugeFunc(
+				prometheus.GaugeOpts{
+					Name: MetricCacheInstances,
+					Help: "Number of distinct cache keys (instances) stored in the cache.",
+				},
+				func() float64 { return float64(c.Len()) },
+			),
+			prometheus.NewGaugeFunc(
+				prometheus.GaugeOpts{
+					Name: MetricCacheConfigMaxSizeBytes,
+					Help: "Configured maximum cache size in bytes.",
+				},
+				func() float64 { return float64(gc.MaxSize) },
+			),
+			newCacheEntriesCollector(c),
+			gcPrunedEntriesTotal,
+			gcSizeLimitExceededTotal,
+		)
+	})
+}

--- a/internal/rulesets/cache/server.go
+++ b/internal/rulesets/cache/server.go
@@ -318,6 +318,7 @@ func (s *ruleSetCacheServer) rungc(ctx context.Context) {
 		case <-ticker.C:
 			prunedByAge := s.cache.Prune(s.gc.MaxAge)
 			if prunedByAge > 0 {
+				gcPrunedEntriesTotal.WithLabelValues(PruneReasonAge).Add(float64(prunedByAge))
 				s.logger.Info("Pruned stale cache entries by age", "count", prunedByAge, "maxAge", s.gc.MaxAge)
 			}
 
@@ -325,11 +326,13 @@ func (s *ruleSetCacheServer) rungc(ctx context.Context) {
 			if currentSize > s.gc.MaxSize {
 				prunedBySize := s.cache.PruneBySize(s.gc.MaxSize)
 				if prunedBySize > 0 {
+					gcPrunedEntriesTotal.WithLabelValues(PruneReasonSize).Add(float64(prunedBySize))
 					s.logger.Info("Pruned cache entries by size", "count", prunedBySize, "maxSize", s.gc.MaxSize, "currentSize", s.cache.TotalSize())
 				}
 
 				finalSize := s.cache.TotalSize()
 				if finalSize > s.gc.MaxSize {
+					gcSizeLimitExceededTotal.Inc()
 					s.logger.Error(errors.New("cache size exceeds maximum"), "CRITICAL: Cache size exceeds maximum even after pruning - latest entry is too large", "currentSize", finalSize, "maxSize", s.gc.MaxSize, "overage", finalSize-s.gc.MaxSize)
 				}
 			}


### PR DESCRIPTION
## Summary

- Adds USE-method (Utilization/Saturation/Errors) metrics for the in-memory RuleSet cache, complementing existing RED metrics
- Six new Prometheus series: `coraza_cache_size_bytes`, `coraza_cache_instances`, `coraza_cache_entries` (per-key via custom Collector), `coraza_cache_config_max_size_bytes`, `coraza_cache_gc_pruned_entries_total` (by reason: age/size), `coraza_cache_gc_size_limit_exceeded_total`
- Registered via `RegisterUSEMetrics()` with `sync.Once` from `setupCacheServer` in `main.go`; GC counters instrumented in `rungc`

## Test plan

- [ ] `GatherAndLint` passes for all 6 new metric names
- [ ] Gauge values reflect cache state (size, instances, config max)
- [ ] Custom collector emits correct per-key entry counts and no stale keys
- [ ] GC prune counters increment for age-based and size-based pruning
- [ ] Size-limit-exceeded counter increments when latest entry exceeds MaxSize

Closes #60

Made with [Cursor](https://cursor.com)