### PR TITLE
Remove unused webhook server configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -201,7 +201,7 @@ run: manifests generate fmt vet
 
 .PHONY: manifests
 manifests: controller-gen
-	"$(CONTROLLER_GEN)" rbac:roleName=coraza-controller-manager crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	"$(CONTROLLER_GEN)" rbac:roleName=coraza-controller-manager crd paths="./..." output:crd:artifacts:config=config/crd/bases
 
 .PHONY: generate
 generate: controller-gen

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -41,7 +41,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	wafv1alpha1 "github.com/networking-incubator/coraza-kubernetes-operator/api/v1alpha1"
 	"github.com/networking-incubator/coraza-kubernetes-operator/internal/controller"
@@ -90,7 +89,6 @@ func main() {
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,
 		Metrics:                buildMetricsServerOptions(cfg, tlsOpts),
-		WebhookServer:          setupWebhookServer(cfg, tlsOpts),
 		HealthProbeBindAddress: cfg.probeAddr,
 		LeaderElection:         cfg.enableLeaderElect,
 		LeaderElectionID:       "waf.k8s.coraza.io",
@@ -137,9 +135,6 @@ type config struct {
 	metricsCertPath   string
 	metricsCertName   string
 	metricsCertKey    string
-	webhookCertPath   string
-	webhookCertName   string
-	webhookCertKey    string
 	cacheGCInterval   time.Duration
 	cacheMaxAge       time.Duration
 	cacheMaxSize      int
@@ -158,9 +153,6 @@ func parseFlags() config {
 	flag.StringVar(&cfg.probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&cfg.enableLeaderElect, "leader-elect", false, "Enable leader election for controller manager. "+
 		"Enabling this will ensure there is only one active controller manager.")
-	flag.StringVar(&cfg.webhookCertPath, "webhook-cert-path", "", "The directory that contains the webhook certificate.")
-	flag.StringVar(&cfg.webhookCertName, "webhook-cert-name", "tls.crt", "The name of the webhook certificate file.")
-	flag.StringVar(&cfg.webhookCertKey, "webhook-cert-key", "tls.key", "The name of the webhook key file.")
 	flag.StringVar(&cfg.metricsCertPath, "metrics-cert-path", "", "The directory that contains the metrics server certificate.")
 	flag.StringVar(&cfg.metricsCertName, "metrics-cert-name", "tls.crt", "The name of the metrics server certificate file.")
 	flag.StringVar(&cfg.metricsCertKey, "metrics-cert-key", "tls.key", "The name of the metrics server key file.")
@@ -228,25 +220,6 @@ func buildMetricsServerOptions(cfg config, tlsOpts []func(*tls.Config)) metricss
 	}
 
 	return opts
-}
-
-// -----------------------------------------------------------------------------
-// Manager Setup
-// -----------------------------------------------------------------------------
-
-func setupWebhookServer(cfg config, tlsOpts []func(*tls.Config)) webhook.Server {
-	opts := webhook.Options{TLSOpts: tlsOpts}
-
-	if len(cfg.webhookCertPath) > 0 {
-		setupLog.Info("Initializing webhook certificate watcher using provided certificates",
-			"webhook-cert-path", cfg.webhookCertPath, "webhook-cert-name", cfg.webhookCertName, "webhook-cert-key", cfg.webhookCertKey)
-
-		opts.CertDir = cfg.webhookCertPath
-		opts.CertName = cfg.webhookCertName
-		opts.KeyName = cfg.webhookCertKey
-	}
-
-	return webhook.NewServer(opts)
 }
 
 // buildCacheOptions returns cache options that scope the NetworkPolicy informer

--- a/cmd/manager/main_test.go
+++ b/cmd/manager/main_test.go
@@ -142,4 +142,3 @@ func TestBuildMetricsServerOptions_SelfSignedWhenNoCert(t *testing.T) {
 	assert.Empty(t, opts.CertName)
 	assert.Empty(t, opts.KeyName)
 }
-

--- a/cmd/manager/main_test.go
+++ b/cmd/manager/main_test.go
@@ -143,24 +143,3 @@ func TestBuildMetricsServerOptions_SelfSignedWhenNoCert(t *testing.T) {
 	assert.Empty(t, opts.KeyName)
 }
 
-// -----------------------------------------------------------------------------
-// setupWebhookServer Tests
-// -----------------------------------------------------------------------------
-
-func TestSetupWebhookServer_NoCertPath(t *testing.T) {
-	cfg := config{}
-
-	server := setupWebhookServer(cfg, nil)
-	assert.NotNil(t, server)
-}
-
-func TestSetupWebhookServer_WithCertPath(t *testing.T) {
-	cfg := config{
-		webhookCertPath: "/webhook-certs",
-		webhookCertName: "webhook.crt",
-		webhookCertKey:  "webhook.key",
-	}
-
-	server := setupWebhookServer(cfg, nil)
-	assert.NotNil(t, server)
-}

--- a/cmd/manager/main_test.go
+++ b/cmd/manager/main_test.go
@@ -18,10 +18,6 @@ package main
 
 import (
 	"crypto/tls"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"reflect"
 	"strings"
 	"testing"
 
@@ -147,55 +143,3 @@ func TestBuildMetricsServerOptions_SelfSignedWhenNoCert(t *testing.T) {
 	assert.Empty(t, opts.KeyName)
 }
 
-// -----------------------------------------------------------------------------
-// Webhook removal regression (issue #295)
-// -----------------------------------------------------------------------------
-
-func TestConfigStructHasNoWebhookFields(t *testing.T) {
-	t.Parallel()
-
-	var cfg config
-	typ := reflect.TypeOf(cfg)
-	for i := 0; i < typ.NumField(); i++ {
-		name := typ.Field(i).Name
-		assert.NotContains(t, strings.ToLower(name), "webhook",
-			"operator config should not carry webhook server fields")
-	}
-}
-
-func TestBuiltManagerHelpExcludesWebhookCertFlags(t *testing.T) {
-	if testing.Short() {
-		t.Skip("subprocess go build skipped in -short mode")
-	}
-
-	repoRoot := findRepoRoot(t)
-	bin := filepath.Join(t.TempDir(), "manager")
-	build := exec.Command("go", "build", "-tags", "no_fs_access", "-o", bin, "./cmd/manager")
-	build.Dir = repoRoot
-	buildOut, err := build.CombinedOutput()
-	require.NoError(t, err, "%s", buildOut)
-
-	help := exec.Command(bin, "-h")
-	helpOut, err := help.CombinedOutput()
-	require.NoError(t, err, "%s", helpOut)
-
-	lower := strings.ToLower(string(helpOut))
-	assert.NotContains(t, lower, "webhook-cert", "removed --webhook-cert-* flags must not reappear in help")
-}
-
-func findRepoRoot(t *testing.T) string {
-	t.Helper()
-
-	dir, err := os.Getwd()
-	require.NoError(t, err)
-	for {
-		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-			return dir
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			t.Fatal("go.mod not found when walking up from cwd")
-		}
-		dir = parent
-	}
-}

--- a/cmd/manager/main_test.go
+++ b/cmd/manager/main_test.go
@@ -18,6 +18,10 @@ package main
 
 import (
 	"crypto/tls"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -143,3 +147,55 @@ func TestBuildMetricsServerOptions_SelfSignedWhenNoCert(t *testing.T) {
 	assert.Empty(t, opts.KeyName)
 }
 
+// -----------------------------------------------------------------------------
+// Webhook removal regression (issue #295)
+// -----------------------------------------------------------------------------
+
+func TestConfigStructHasNoWebhookFields(t *testing.T) {
+	t.Parallel()
+
+	var cfg config
+	typ := reflect.TypeOf(cfg)
+	for i := 0; i < typ.NumField(); i++ {
+		name := typ.Field(i).Name
+		assert.NotContains(t, strings.ToLower(name), "webhook",
+			"operator config should not carry webhook server fields")
+	}
+}
+
+func TestBuiltManagerHelpExcludesWebhookCertFlags(t *testing.T) {
+	if testing.Short() {
+		t.Skip("subprocess go build skipped in -short mode")
+	}
+
+	repoRoot := findRepoRoot(t)
+	bin := filepath.Join(t.TempDir(), "manager")
+	build := exec.Command("go", "build", "-tags", "no_fs_access", "-o", bin, "./cmd/manager")
+	build.Dir = repoRoot
+	buildOut, err := build.CombinedOutput()
+	require.NoError(t, err, "%s", buildOut)
+
+	help := exec.Command(bin, "-h")
+	helpOut, err := help.CombinedOutput()
+	require.NoError(t, err, "%s", helpOut)
+
+	lower := strings.ToLower(string(helpOut))
+	assert.NotContains(t, lower, "webhook-cert", "removed --webhook-cert-* flags must not reappear in help")
+}
+
+func findRepoRoot(t *testing.T) string {
+	t.Helper()
+
+	dir, err := os.Getwd()
+	require.NoError(t, err)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("go.mod not found when walking up from cwd")
+		}
+		dir = parent
+	}
+}


### PR DESCRIPTION
## Summary

- Remove `--webhook-cert-path`, `--webhook-cert-name`, `--webhook-cert-key` flags and corresponding `config` struct fields from `cmd/manager/main.go`
- Remove `setupWebhookServer` helper and `WebhookServer` from `ctrl.Options`
- Remove `sigs.k8s.io/controller-runtime/pkg/webhook` import
- Remove `TestSetupWebhookServer_NoCertPath` and `TestSetupWebhookServer_WithCertPath` tests from `cmd/manager/main_test.go`
- Drop `webhook` from the `controller-gen` invocation in the Makefile `manifests` target

No behavior change: the webhook server was never started because `GetWebhookServer()` was never called. These flags were no-ops.

Closes networking-incubator/coraza-kubernetes-operator#295

## Test plan

- [ ] Existing unit tests pass (webhook tests removed, all others untouched)
- [ ] `make manifests` produces unchanged CRD and RBAC output (no webhook markers existed)
- [ ] Operator starts without the removed flags

Made with [Cursor](https://cursor.com)