### PR TITLE
feat: periodic re-apply of Istio prerequisite resources

### DIFF
--- a/charts/coraza-kubernetes-operator/templates/deployment.yaml
+++ b/charts/coraza-kubernetes-operator/templates/deployment.yaml
@@ -59,7 +59,7 @@ spec:
             - --istio-revision={{ .Values.istio.revision }}
             {{- end }}
             - --operator-name={{ include "coraza-operator.fullname" . }}
-            {{- if .Values.istio.prerequisitesReconcileInterval }}
+            {{- if ne (toString .Values.istio.prerequisitesReconcileInterval) "" }}
             - --istio-prerequisites-reconcile-interval={{ .Values.istio.prerequisitesReconcileInterval }}
             {{- end }}
             {{- if .Values.defaultWasmImage }}

--- a/charts/coraza-kubernetes-operator/templates/deployment.yaml
+++ b/charts/coraza-kubernetes-operator/templates/deployment.yaml
@@ -59,6 +59,9 @@ spec:
             - --istio-revision={{ .Values.istio.revision }}
             {{- end }}
             - --operator-name={{ include "coraza-operator.fullname" . }}
+            {{- if .Values.istio.prerequisitesReconcileInterval }}
+            - --istio-prerequisites-reconcile-interval={{ .Values.istio.prerequisitesReconcileInterval }}
+            {{- end }}
             {{- if .Values.defaultWasmImage }}
             - --default-wasm-image={{ .Values.defaultWasmImage }}
             {{- end }}

--- a/charts/coraza-kubernetes-operator/values.yaml
+++ b/charts/coraza-kubernetes-operator/values.yaml
@@ -50,6 +50,12 @@ logging:
 istio:
   # When empty, the operator does not set an Istio revision label on managed resources.
   revision: ""
+  # Interval at which Istio prerequisite resources (ServiceEntry/DestinationRule)
+  # are re-applied for self-healing after accidental deletion or drift.
+  # Set to "0s" to disable periodic re-apply (startup-only).
+  # Operator-managed Istio resources are reconciled to desired state on this
+  # interval; manual edits to those objects will be reverted.
+  prerequisitesReconcileInterval: "5m"
 
 # Default WASM plugin OCI URL when an Engine omits spec.driver.istio.wasm.image.
 # When empty, the operator's built-in default (internal/defaults.DefaultCorazaWasmOCIReference) is used.

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -147,7 +147,8 @@ type config struct {
 	envoyClusterName  string
 	istioRevision     string
 	defaultWasmImage  string
-	operatorName      string
+	operatorName                       string
+	istioPrerequisitesReconcileInterval time.Duration
 }
 
 func parseFlags() config {
@@ -173,6 +174,10 @@ func parseFlags() config {
 	flag.StringVar(&cfg.defaultWasmImage, "default-wasm-image", resolveDefaultWasmImage(),
 		"Default OCI reference for the Coraza WASM plugin when an Engine omits spec.driver.istio.wasm.image")
 	flag.StringVar(&cfg.operatorName, "operator-name", "", "The operator release name used to derive managed resource names (when unset, Istio prerequisites are skipped)")
+	flag.DurationVar(&cfg.istioPrerequisitesReconcileInterval, "istio-prerequisites-reconcile-interval", controller.DefaultIstioPrerequisitesReconcileInterval,
+		"Interval at which Istio prerequisite resources (ServiceEntry/DestinationRule) are re-applied for self-healing. "+
+			"Set to 0 to disable periodic re-apply and only apply at startup. "+
+			"For HA deployments, use --leader-elect so only the leader runs this.")
 
 	opts := zap.Options{Development: false}
 	opts.BindFlags(flag.CommandLine)
@@ -287,7 +292,7 @@ func setupIstioPrerequisites(mgr ctrl.Manager, cfg config, podNamespace string) 
 		return
 	}
 
-	istioPrereqs := controller.NewIstioPrerequisites(mgr.GetClient(), mgr.GetAPIReader(), cfg.operatorName, podNamespace, cfg.istioRevision)
+	istioPrereqs := controller.NewIstioPrerequisites(mgr.GetClient(), mgr.GetAPIReader(), cfg.operatorName, podNamespace, cfg.istioRevision, cfg.istioPrerequisitesReconcileInterval)
 	if err := mgr.Add(istioPrereqs); err != nil {
 		setupLog.Error(err, "unable to add Istio prerequisites runnable to manager")
 		os.Exit(1)

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -147,7 +147,8 @@ type config struct {
 	envoyClusterName  string
 	istioRevision     string
 	defaultWasmImage  string
-	operatorName                       string
+	operatorName      string
+
 	istioPrerequisitesReconcileInterval time.Duration
 }
 

--- a/internal/charttest/deployment_helm_guard_test.go
+++ b/internal/charttest/deployment_helm_guard_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright Coraza Kubernetes Operator contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package charttest_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// Helm's Go-template truthiness treats numeric 0 as false, so
+// `if .Values.istio.prerequisitesReconcileInterval` dropped the CLI flag for
+// users who set 0 to disable periodic reconcile. Guard against regression.
+func TestHelmDeployment_IstioPrerequisitesIntervalUsesNonEmptyStringGuard(t *testing.T) {
+	t.Parallel()
+	path := deploymentYAMLPath(t)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	const want = `ne (toString .Values.istio.prerequisitesReconcileInterval) ""`
+	if !strings.Contains(string(data), want) {
+		t.Fatalf("deployment template must contain %q so 0 / 0s values still render the flag", want)
+	}
+}
+
+func deploymentYAMLPath(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	// internal/charttest -> repo root -> charts/.../deployment.yaml
+	return filepath.Join(filepath.Dir(file), "..", "..", "charts", "coraza-kubernetes-operator", "templates", "deployment.yaml")
+}

--- a/internal/controller/engine_controller_istio_prerequisites.go
+++ b/internal/controller/engine_controller_istio_prerequisites.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
@@ -30,44 +31,78 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// DefaultIstioPrerequisitesReconcileInterval is the default interval at which
+// the operator re-applies the Istio ServiceEntry and DestinationRule.
+// Set to 0 to disable periodic re-apply (startup-only).
+const DefaultIstioPrerequisitesReconcileInterval = 5 * time.Minute
+
 // -----------------------------------------------------------------------------
 // Istio Prerequisites
 // -----------------------------------------------------------------------------
 
 // IstioPrerequisites creates the Istio ServiceEntry and DestinationRule
 // resources required for the RuleSet cache server to be reachable from
-// Envoy sidecars within the mesh. These resources are applied once at
-// startup using server-side apply.
+// Envoy sidecars within the mesh. Resources are applied at startup and,
+// when reconcileInterval > 0, periodically re-applied via server-side
+// apply so they self-heal after accidental deletion or drift.
 type IstioPrerequisites struct {
-	client        client.Client
-	reader        client.Reader
-	operatorName  string
-	namespace     string
-	istioRevision string
+	client            client.Client
+	reader            client.Reader
+	operatorName      string
+	namespace         string
+	istioRevision     string
+	reconcileInterval time.Duration
 }
 
 // NewIstioPrerequisites returns a new IstioPrerequisites runnable.
 // The reader should be a direct API reader (not cached) to avoid
 // setting up a cluster-wide Deployment informer for a one-shot lookup.
-func NewIstioPrerequisites(c client.Client, reader client.Reader, operatorName, namespace, istioRevision string) *IstioPrerequisites {
+//
+// When reconcileInterval is positive, Start will re-apply the resources
+// on that cadence. Zero or negative disables periodic re-apply (startup only).
+func NewIstioPrerequisites(c client.Client, reader client.Reader, operatorName, namespace, istioRevision string, reconcileInterval time.Duration) *IstioPrerequisites {
 	return &IstioPrerequisites{
-		client:        c,
-		reader:        reader,
-		operatorName:  operatorName,
-		namespace:     namespace,
-		istioRevision: istioRevision,
+		client:            c,
+		reader:            reader,
+		operatorName:      operatorName,
+		namespace:         namespace,
+		istioRevision:     istioRevision,
+		reconcileInterval: reconcileInterval,
 	}
 }
 
 // Start applies the Istio ServiceEntry and DestinationRule for the
-// RuleSet cache server. It satisfies the manager.Runnable interface.
+// RuleSet cache server and, when reconcileInterval > 0, re-applies
+// them periodically until ctx is cancelled. It satisfies the
+// manager.Runnable interface and never returns a non-nil error from
+// apply failures (the manager stays running).
 func (p *IstioPrerequisites) Start(ctx context.Context) error {
 	log := ctrl.Log.WithName("istio-prerequisites")
 
 	if err := p.apply(ctx, log); err != nil {
 		log.Error(err, "Failed to apply Istio prerequisites (controllers will continue without them)")
 	}
-	return nil
+
+	if p.reconcileInterval <= 0 {
+		log.Info("Periodic Istio prerequisites reconciliation is disabled")
+		return nil
+	}
+
+	log.Info("Starting periodic Istio prerequisites reconciliation", "interval", p.reconcileInterval)
+	ticker := time.NewTicker(p.reconcileInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.Info("Stopping periodic Istio prerequisites reconciliation")
+			return nil
+		case <-ticker.C:
+			if err := p.apply(ctx, log); err != nil {
+				log.Error(err, "Failed to re-apply Istio prerequisites")
+			}
+		}
+	}
 }
 
 func (p *IstioPrerequisites) apply(ctx context.Context, log logr.Logger) error {

--- a/internal/controller/engine_controller_istio_prerequisites_test.go
+++ b/internal/controller/engine_controller_istio_prerequisites_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -142,7 +143,7 @@ func TestIstioPrerequisites_Apply(t *testing.T) {
 	namespace := setupTestNamespace(t, ctx)
 	deploy := createDeployment(t, ctx, "test-op", namespace)
 
-	p := NewIstioPrerequisites(k8sClient, k8sClient, "test-op", namespace, "")
+	p := NewIstioPrerequisites(k8sClient, k8sClient, "test-op", namespace, "", 0)
 	log := ctrl.Log.WithName("test")
 	require.NoError(t, p.apply(ctx, log))
 
@@ -180,7 +181,7 @@ func TestIstioPrerequisites_ApplyIdempotent(t *testing.T) {
 	namespace := setupTestNamespace(t, ctx)
 	createDeployment(t, ctx, "test-op-idem", namespace)
 
-	p := NewIstioPrerequisites(k8sClient, k8sClient, "test-op-idem", namespace, "")
+	p := NewIstioPrerequisites(k8sClient, k8sClient, "test-op-idem", namespace, "", 0)
 	log := ctrl.Log.WithName("test-idempotent")
 
 	require.NoError(t, p.apply(ctx, log), "first apply")
@@ -192,7 +193,7 @@ func TestIstioPrerequisites_ApplyWithIstioRevision(t *testing.T) {
 	namespace := setupTestNamespace(t, ctx)
 	createDeployment(t, ctx, "test-op-rev", namespace)
 
-	p := NewIstioPrerequisites(k8sClient, k8sClient, "test-op-rev", namespace, "canary")
+	p := NewIstioPrerequisites(k8sClient, k8sClient, "test-op-rev", namespace, "canary", 0)
 	log := ctrl.Log.WithName("test-revision")
 	require.NoError(t, p.apply(ctx, log))
 
@@ -210,7 +211,7 @@ func TestIstioPrerequisites_ApplyDeploymentNotFound(t *testing.T) {
 	ctx := context.Background()
 	namespace := setupTestNamespace(t, ctx)
 
-	p := NewIstioPrerequisites(k8sClient, k8sClient, "no-such-deploy", namespace, "")
+	p := NewIstioPrerequisites(k8sClient, k8sClient, "no-such-deploy", namespace, "", 0)
 	log := ctrl.Log.WithName("test-not-found")
 	err := p.apply(ctx, log)
 	require.Error(t, err)
@@ -221,9 +222,138 @@ func TestIstioPrerequisites_StartReturnsNilOnError(t *testing.T) {
 	ctx := context.Background()
 	namespace := setupTestNamespace(t, ctx)
 
-	p := NewIstioPrerequisites(k8sClient, k8sClient, "no-such-deploy", namespace, "")
+	p := NewIstioPrerequisites(k8sClient, k8sClient, "no-such-deploy", namespace, "", 0)
 	err := p.Start(ctx)
 	assert.NoError(t, err, "Start() must return nil even when apply fails")
+}
+
+func TestIstioPrerequisites_PeriodicReapply(t *testing.T) {
+	ctx := context.Background()
+	namespace := setupTestNamespace(t, ctx)
+	createDeployment(t, ctx, "test-op-periodic", namespace)
+
+	interval := 50 * time.Millisecond
+	p := NewIstioPrerequisites(k8sClient, k8sClient, "test-op-periodic", namespace, "", interval)
+
+	startCtx, cancel := context.WithCancel(ctx)
+	done := make(chan error, 1)
+	go func() {
+		done <- p.Start(startCtx)
+	}()
+
+	resourceName := "test-op-periodic-ruleset-cache"
+
+	// Wait for the initial apply to create the ServiceEntry.
+	require.Eventually(t, func() bool {
+		se := &unstructured.Unstructured{}
+		se.SetGroupVersionKind(schema.GroupVersionKind{
+			Group: "networking.istio.io", Version: "v1", Kind: "ServiceEntry",
+		})
+		return k8sClient.Get(ctx, types.NamespacedName{
+			Name: resourceName, Namespace: namespace,
+		}, se) == nil
+	}, 2*time.Second, 10*time.Millisecond, "ServiceEntry should exist after initial apply")
+
+	// Delete the ServiceEntry and verify it gets re-created by the periodic loop.
+	se := &unstructured.Unstructured{}
+	se.SetGroupVersionKind(schema.GroupVersionKind{
+		Group: "networking.istio.io", Version: "v1", Kind: "ServiceEntry",
+	})
+	se.SetName(resourceName)
+	se.SetNamespace(namespace)
+	require.NoError(t, k8sClient.Delete(ctx, se))
+
+	require.Eventually(t, func() bool {
+		check := &unstructured.Unstructured{}
+		check.SetGroupVersionKind(schema.GroupVersionKind{
+			Group: "networking.istio.io", Version: "v1", Kind: "ServiceEntry",
+		})
+		return k8sClient.Get(ctx, types.NamespacedName{
+			Name: resourceName, Namespace: namespace,
+		}, check) == nil
+	}, 2*time.Second, 10*time.Millisecond, "ServiceEntry should be re-created by periodic reconciliation")
+
+	cancel()
+	require.NoError(t, <-done, "Start should return nil on context cancellation")
+}
+
+func TestIstioPrerequisites_StartBlocksUntilCancelled(t *testing.T) {
+	ctx := context.Background()
+	namespace := setupTestNamespace(t, ctx)
+	createDeployment(t, ctx, "test-op-block", namespace)
+
+	p := NewIstioPrerequisites(k8sClient, k8sClient, "test-op-block", namespace, "", 100*time.Millisecond)
+
+	startCtx, cancel := context.WithCancel(ctx)
+	done := make(chan error, 1)
+	go func() {
+		done <- p.Start(startCtx)
+	}()
+
+	// Start should not return while context is active.
+	select {
+	case err := <-done:
+		t.Fatalf("Start returned prematurely: %v", err)
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		assert.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start did not return after context cancellation")
+	}
+}
+
+func TestIstioPrerequisites_ZeroIntervalReturnsImmediately(t *testing.T) {
+	ctx := context.Background()
+	namespace := setupTestNamespace(t, ctx)
+
+	p := NewIstioPrerequisites(k8sClient, k8sClient, "no-such-deploy", namespace, "", 0)
+	done := make(chan error, 1)
+	go func() {
+		done <- p.Start(ctx)
+	}()
+
+	select {
+	case err := <-done:
+		assert.NoError(t, err, "Start with interval=0 should return nil immediately")
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start with interval=0 should return immediately, not block")
+	}
+}
+
+func TestIstioPrerequisites_PeriodicLoopSurvivesMultipleTicks(t *testing.T) {
+	ctx := context.Background()
+	namespace := setupTestNamespace(t, ctx)
+	createDeployment(t, ctx, "test-op-count", namespace)
+
+	p := NewIstioPrerequisites(k8sClient, k8sClient, "test-op-count", namespace, "", 30*time.Millisecond)
+
+	startCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- p.Start(startCtx)
+	}()
+
+	// Wait long enough for multiple periodic ticks to fire.
+	time.Sleep(120 * time.Millisecond)
+
+	// Verify resources exist (proves apply ran without crashing the loop).
+	resourceName := "test-op-count-ruleset-cache"
+	se := &unstructured.Unstructured{}
+	se.SetGroupVersionKind(schema.GroupVersionKind{
+		Group: "networking.istio.io", Version: "v1", Kind: "ServiceEntry",
+	})
+	require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{
+		Name: resourceName, Namespace: namespace,
+	}, se))
+
+	cancel()
+	require.NoError(t, <-done)
 }
 
 // -----------------------------------------------------------------------------

--- a/internal/controller/engine_controller_istio_prerequisites_test.go
+++ b/internal/controller/engine_controller_istio_prerequisites_test.go
@@ -324,6 +324,103 @@ func TestIstioPrerequisites_ZeroIntervalReturnsImmediately(t *testing.T) {
 	}
 }
 
+func TestIstioPrerequisites_NegativeIntervalDisablesPeriodic(t *testing.T) {
+	ctx := context.Background()
+	namespace := setupTestNamespace(t, ctx)
+
+	// reconcileInterval <= 0 must disable the ticker loop (same as zero).
+	p := NewIstioPrerequisites(k8sClient, k8sClient, "no-such-deploy", namespace, "", -1*time.Second)
+	done := make(chan error, 1)
+	go func() {
+		done <- p.Start(ctx)
+	}()
+
+	select {
+	case err := <-done:
+		assert.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start with negative interval should return immediately, not block")
+	}
+}
+
+func TestIstioPrerequisites_PeriodicStartSurvivesMissingDeployment(t *testing.T) {
+	ctx := context.Background()
+	namespace := setupTestNamespace(t, ctx)
+
+	p := NewIstioPrerequisites(k8sClient, k8sClient, "missing-deploy", namespace, "", 40*time.Millisecond)
+	startCtx, cancel := context.WithCancel(ctx)
+	done := make(chan error, 1)
+	go func() {
+		done <- p.Start(startCtx)
+	}()
+
+	// Several ticks: apply keeps failing but Start must not exit or return a non-nil error.
+	time.Sleep(150 * time.Millisecond)
+
+	cancel()
+	select {
+	case err := <-done:
+		assert.NoError(t, err, "Start must return nil on cancel even when apply never succeeds")
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start did not return after context cancellation")
+	}
+}
+
+func TestIstioPrerequisites_PeriodicReapplyCorrectsSpecDrift(t *testing.T) {
+	ctx := context.Background()
+	namespace := setupTestNamespace(t, ctx)
+	createDeployment(t, ctx, "test-op-drift", namespace)
+
+	interval := 50 * time.Millisecond
+	p := NewIstioPrerequisites(k8sClient, k8sClient, "test-op-drift", namespace, "", interval)
+
+	startCtx, cancel := context.WithCancel(ctx)
+	done := make(chan error, 1)
+	go func() {
+		done <- p.Start(startCtx)
+	}()
+
+	resourceName := "test-op-drift-ruleset-cache"
+	require.Eventually(t, func() bool {
+		se := &unstructured.Unstructured{}
+		se.SetGroupVersionKind(schema.GroupVersionKind{
+			Group: "networking.istio.io", Version: "v1", Kind: "ServiceEntry",
+		})
+		return k8sClient.Get(ctx, types.NamespacedName{
+			Name: resourceName, Namespace: namespace,
+		}, se) == nil
+	}, 2*time.Second, 10*time.Millisecond, "initial ServiceEntry must exist")
+
+	se := &unstructured.Unstructured{}
+	se.SetGroupVersionKind(schema.GroupVersionKind{
+		Group: "networking.istio.io", Version: "v1", Kind: "ServiceEntry",
+	})
+	require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{
+		Name: resourceName, Namespace: namespace,
+	}, se))
+
+	// Simulate an admin mutating operator-managed fields; next SSA tick should revert.
+	require.NoError(t, unstructured.SetNestedField(se.Object, "MESH_EXTERNAL", "spec", "location"))
+	require.NoError(t, k8sClient.Update(ctx, se))
+
+	require.Eventually(t, func() bool {
+		check := &unstructured.Unstructured{}
+		check.SetGroupVersionKind(schema.GroupVersionKind{
+			Group: "networking.istio.io", Version: "v1", Kind: "ServiceEntry",
+		})
+		if err := k8sClient.Get(ctx, types.NamespacedName{
+			Name: resourceName, Namespace: namespace,
+		}, check); err != nil {
+			return false
+		}
+		loc, found, err := unstructured.NestedString(check.Object, "spec", "location")
+		return err == nil && found && loc == "MESH_INTERNAL"
+	}, 3*time.Second, 20*time.Millisecond, "periodic SSA should restore spec.location after drift")
+
+	cancel()
+	require.NoError(t, <-done)
+}
+
 func TestIstioPrerequisites_PeriodicLoopSurvivesMultipleTicks(t *testing.T) {
 	ctx := context.Background()
 	namespace := setupTestNamespace(t, ctx)


### PR DESCRIPTION
## Summary

- Extends `IstioPrerequisites` runnable to periodically re-apply the Istio `ServiceEntry` and `DestinationRule` via SSA on a configurable interval (default 5m), self-healing after accidental deletion or drift.
- Adds `--istio-prerequisites-reconcile-interval` flag (0 disables periodic re-apply, preserving startup-only behavior).
- Exposes the interval in the Helm chart as `istio.prerequisitesReconcileInterval`.
- No RBAC changes — reuses existing patch-by-name SSA path.

## Design decisions

- **Tier 1 only** (per architectural guidance): periodic SSA re-apply, no watches, no `list`/`watch` RBAC expansion.
- **`0` disables periodic**: `Start()` returns immediately after the initial apply, matching legacy behavior.
- **Operator-managed objects are authoritative**: manual edits to the ServiceEntry/DestinationRule will be reverted on the next tick. Changes must go through operator config/Helm.
- **Leader election**: with `--leader-elect` (default in Helm), only the leader runs the periodic loop. Without it, all replicas apply redundantly (SSA is safe, just extra writes).

## Test plan

- [ ] `TestIstioPrerequisites_PeriodicReapply` — deletes ServiceEntry, verifies periodic loop re-creates it
- [ ] `TestIstioPrerequisites_StartBlocksUntilCancelled` — verifies Start blocks with interval > 0 and returns on cancel
- [ ] `TestIstioPrerequisites_ZeroIntervalReturnsImmediately` — verifies interval=0 preserves legacy behavior
- [ ] `TestIstioPrerequisites_PeriodicLoopSurvivesMultipleTicks` — verifies loop stays alive across multiple ticks
- [ ] Existing tests pass with updated constructor signature (interval=0)

Closes #64

Made with [Cursor](https://cursor.com)