### PR TITLE
feat: register coraza-prefixed Prometheus metrics for Engine and RuleSet CRs

### DIFF
--- a/internal/controller/engine_controller.go
+++ b/internal/controller/engine_controller.go
@@ -44,6 +44,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	wafv1alpha1 "github.com/networking-incubator/coraza-kubernetes-operator/api/v1alpha1"
+	crmetrics "github.com/networking-incubator/coraza-kubernetes-operator/internal/controller/metrics"
 )
 
 // -----------------------------------------------------------------------------
@@ -136,6 +137,7 @@ func (r *EngineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	if err := r.Get(ctx, req.NamespacedName, &engine); err != nil {
 		if apierrors.IsNotFound(err) {
 			logDebug(log, req, "Engine", "Resource not found")
+			crmetrics.DeleteEngineMetrics(req.Namespace, req.Name)
 			// Best-effort cleanup: remove any orphaned NetworkPolicy that may
 			// remain if the Engine was deleted before the finalizer was added
 			// (e.g., race during upgrade or legacy Engine without finalizer).
@@ -167,6 +169,8 @@ func (r *EngineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return ctrl.Result{RequeueAfter: 100 * time.Millisecond}, nil
 	}
 
+	crmetrics.RecordEngineInfo(engine.Namespace, engine.Name, string(engine.Spec.FailurePolicy))
+
 	logDebug(log, req, "Engine", "Applying conditions")
 	if engine.Status == nil {
 		engine.Status = &wafv1alpha1.EngineStatus{}
@@ -180,6 +184,7 @@ func (r *EngineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			return ctrl.Result{}, err
 		}
 		logConditionTransitions(log, req, "Engine", before, engine.Status.Conditions)
+		recordConditionMetrics("Engine", req.Namespace, req.Name, engine.Status.Conditions)
 	}
 
 	logDebug(log, req, "Engine", "Checking referenced RuleSet status")

--- a/internal/controller/metrics/metrics.go
+++ b/internal/controller/metrics/metrics.go
@@ -72,6 +72,8 @@ func init() {
 // RecordEngineInfo sets the coraza_engine_info gauge for the given Engine.
 // failurePolicy is the literal spec value (may be empty if user omitted it).
 func RecordEngineInfo(namespace, name, failurePolicy string) {
+	// Drop prior failure_policy label sets so a spec change cannot leave stale 1s.
+	engineInfo.DeletePartialMatch(prometheus.Labels{"namespace": namespace, "name": name})
 	engineInfo.WithLabelValues(namespace, name, failurePolicy).Set(1)
 }
 

--- a/internal/controller/metrics/metrics.go
+++ b/internal/controller/metrics/metrics.go
@@ -1,0 +1,132 @@
+/*
+Copyright Coraza Kubernetes Operator contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package metrics defines coraza_engine_* and coraza_ruleset_* Prometheus
+// metrics for the operator's custom resources. Metrics are registered on
+// controller-runtime's global registry.
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+const (
+	MetricEngineInfo         = "coraza_engine_info"
+	MetricEngineCondition    = "coraza_engine_condition"
+	MetricRuleSetCondition   = "coraza_ruleset_condition"
+)
+
+var conditionStatuses = []string{
+	string(metav1.ConditionTrue),
+	string(metav1.ConditionFalse),
+	string(metav1.ConditionUnknown),
+}
+
+var trackedConditionTypes = []string{"Ready", "Degraded", "Progressing"}
+
+var (
+	engineInfo = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: MetricEngineInfo,
+			Help: "Info metric for Engine custom resources. Value is always 1 for active engines.",
+		},
+		[]string{"namespace", "name", "failure_policy"},
+	)
+
+	engineCondition = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: MetricEngineCondition,
+			Help: "Condition status for Engine custom resources. For each (namespace, name, type), exactly one status is 1.",
+		},
+		[]string{"namespace", "name", "type", "status"},
+	)
+
+	ruleSetCondition = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: MetricRuleSetCondition,
+			Help: "Condition status for RuleSet custom resources. For each (namespace, name, type), exactly one status is 1.",
+		},
+		[]string{"namespace", "name", "type", "status"},
+	)
+)
+
+func init() {
+	metrics.Registry.MustRegister(engineInfo, engineCondition, ruleSetCondition)
+}
+
+// RecordEngineInfo sets the coraza_engine_info gauge for the given Engine.
+// failurePolicy is the literal spec value (may be empty if user omitted it).
+func RecordEngineInfo(namespace, name, failurePolicy string) {
+	engineInfo.WithLabelValues(namespace, name, failurePolicy).Set(1)
+}
+
+// RecordEngineConditions updates coraza_engine_condition gauges for all
+// tracked condition types. For each type, the matching status gets value 1
+// and the other two get 0. If a condition type is absent from the list,
+// all three statuses are set to 0.
+func RecordEngineConditions(namespace, name string, conditions []metav1.Condition) {
+	recordConditions(engineCondition, namespace, name, conditions)
+}
+
+// RecordRuleSetConditions updates coraza_ruleset_condition gauges for all
+// tracked condition types, following the same semantics as RecordEngineConditions.
+func RecordRuleSetConditions(namespace, name string, conditions []metav1.Condition) {
+	recordConditions(ruleSetCondition, namespace, name, conditions)
+}
+
+// DeleteEngineMetrics removes all metric series for the given Engine.
+func DeleteEngineMetrics(namespace, name string) {
+	engineInfo.DeletePartialMatch(prometheus.Labels{"namespace": namespace, "name": name})
+	engineCondition.DeletePartialMatch(prometheus.Labels{"namespace": namespace, "name": name})
+}
+
+// DeleteRuleSetMetrics removes all metric series for the given RuleSet.
+func DeleteRuleSetMetrics(namespace, name string) {
+	ruleSetCondition.DeletePartialMatch(prometheus.Labels{"namespace": namespace, "name": name})
+}
+
+func recordConditions(vec *prometheus.GaugeVec, namespace, name string, conditions []metav1.Condition) {
+	for _, ct := range trackedConditionTypes {
+		activeStatus := findConditionStatus(conditions, ct)
+		for _, s := range conditionStatuses {
+			val := float64(0)
+			if s == activeStatus {
+				val = 1
+			}
+			vec.WithLabelValues(namespace, name, ct, s).Set(val)
+		}
+	}
+}
+
+func findConditionStatus(conditions []metav1.Condition, condType string) string {
+	for i := range conditions {
+		if conditions[i].Type == condType {
+			return string(conditions[i].Status)
+		}
+	}
+	return ""
+}
+
+// EngineInfoVec returns the underlying GaugeVec for testing purposes only.
+func EngineInfoVec() *prometheus.GaugeVec { return engineInfo }
+
+// EngineConditionVec returns the underlying GaugeVec for testing purposes only.
+func EngineConditionVec() *prometheus.GaugeVec { return engineCondition }
+
+// RuleSetConditionVec returns the underlying GaugeVec for testing purposes only.
+func RuleSetConditionVec() *prometheus.GaugeVec { return ruleSetCondition }

--- a/internal/controller/metrics/metrics_test.go
+++ b/internal/controller/metrics/metrics_test.go
@@ -1,0 +1,224 @@
+/*
+Copyright Coraza Kubernetes Operator contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+func resetMetrics(t *testing.T) {
+	t.Helper()
+	engineInfo.Reset()
+	engineCondition.Reset()
+	ruleSetCondition.Reset()
+}
+
+func TestMetricsRegistered(t *testing.T) {
+	problems, err := testutil.GatherAndLint(metrics.Registry,
+		MetricEngineInfo,
+		MetricEngineCondition,
+		MetricRuleSetCondition,
+	)
+	require.NoError(t, err)
+	assert.Empty(t, problems, "metric lint problems")
+}
+
+func TestRecordEngineInfo(t *testing.T) {
+	resetMetrics(t)
+
+	RecordEngineInfo("default", "my-engine", "fail")
+
+	val := testutil.ToFloat64(engineInfo.WithLabelValues("default", "my-engine", "fail"))
+	assert.Equal(t, float64(1), val)
+}
+
+func TestRecordEngineInfo_EmptyFailurePolicy(t *testing.T) {
+	resetMetrics(t)
+
+	RecordEngineInfo("default", "my-engine", "")
+
+	val := testutil.ToFloat64(engineInfo.WithLabelValues("default", "my-engine", ""))
+	assert.Equal(t, float64(1), val)
+}
+
+func TestRecordEngineConditions_Ready(t *testing.T) {
+	resetMetrics(t)
+
+	conditions := []metav1.Condition{
+		{Type: "Ready", Status: metav1.ConditionTrue},
+	}
+	RecordEngineConditions("ns", "eng", conditions)
+
+	assert.Equal(t, float64(1), testutil.ToFloat64(engineCondition.WithLabelValues("ns", "eng", "Ready", "True")))
+	assert.Equal(t, float64(0), testutil.ToFloat64(engineCondition.WithLabelValues("ns", "eng", "Ready", "False")))
+	assert.Equal(t, float64(0), testutil.ToFloat64(engineCondition.WithLabelValues("ns", "eng", "Ready", "Unknown")))
+
+	// Absent conditions should all be 0
+	assert.Equal(t, float64(0), testutil.ToFloat64(engineCondition.WithLabelValues("ns", "eng", "Degraded", "True")))
+	assert.Equal(t, float64(0), testutil.ToFloat64(engineCondition.WithLabelValues("ns", "eng", "Degraded", "False")))
+	assert.Equal(t, float64(0), testutil.ToFloat64(engineCondition.WithLabelValues("ns", "eng", "Degraded", "Unknown")))
+}
+
+func TestRecordEngineConditions_Degraded(t *testing.T) {
+	resetMetrics(t)
+
+	conditions := []metav1.Condition{
+		{Type: "Ready", Status: metav1.ConditionFalse},
+		{Type: "Degraded", Status: metav1.ConditionTrue},
+	}
+	RecordEngineConditions("ns", "eng", conditions)
+
+	assert.Equal(t, float64(0), testutil.ToFloat64(engineCondition.WithLabelValues("ns", "eng", "Ready", "True")))
+	assert.Equal(t, float64(1), testutil.ToFloat64(engineCondition.WithLabelValues("ns", "eng", "Ready", "False")))
+	assert.Equal(t, float64(1), testutil.ToFloat64(engineCondition.WithLabelValues("ns", "eng", "Degraded", "True")))
+	assert.Equal(t, float64(0), testutil.ToFloat64(engineCondition.WithLabelValues("ns", "eng", "Degraded", "False")))
+}
+
+func TestRecordEngineConditions_AllAbsent(t *testing.T) {
+	resetMetrics(t)
+
+	RecordEngineConditions("ns", "eng", nil)
+
+	for _, ct := range trackedConditionTypes {
+		for _, s := range conditionStatuses {
+			assert.Equal(t, float64(0), testutil.ToFloat64(engineCondition.WithLabelValues("ns", "eng", ct, s)),
+				"expected 0 for absent condition %s/%s", ct, s)
+		}
+	}
+}
+
+func TestRecordRuleSetConditions(t *testing.T) {
+	resetMetrics(t)
+
+	conditions := []metav1.Condition{
+		{Type: "Ready", Status: metav1.ConditionTrue},
+	}
+	RecordRuleSetConditions("ns", "rs", conditions)
+
+	assert.Equal(t, float64(1), testutil.ToFloat64(ruleSetCondition.WithLabelValues("ns", "rs", "Ready", "True")))
+	assert.Equal(t, float64(0), testutil.ToFloat64(ruleSetCondition.WithLabelValues("ns", "rs", "Ready", "False")))
+}
+
+func TestRecordConditions_TransitionsCorrectly(t *testing.T) {
+	resetMetrics(t)
+
+	// Start Progressing
+	conditions := []metav1.Condition{
+		{Type: "Ready", Status: metav1.ConditionFalse},
+		{Type: "Progressing", Status: metav1.ConditionTrue},
+	}
+	RecordEngineConditions("ns", "eng", conditions)
+	assert.Equal(t, float64(1), testutil.ToFloat64(engineCondition.WithLabelValues("ns", "eng", "Progressing", "True")))
+	assert.Equal(t, float64(0), testutil.ToFloat64(engineCondition.WithLabelValues("ns", "eng", "Ready", "True")))
+
+	// Transition to Ready
+	conditions = []metav1.Condition{
+		{Type: "Ready", Status: metav1.ConditionTrue},
+	}
+	RecordEngineConditions("ns", "eng", conditions)
+	assert.Equal(t, float64(1), testutil.ToFloat64(engineCondition.WithLabelValues("ns", "eng", "Ready", "True")))
+	assert.Equal(t, float64(0), testutil.ToFloat64(engineCondition.WithLabelValues("ns", "eng", "Progressing", "True")))
+	assert.Equal(t, float64(0), testutil.ToFloat64(engineCondition.WithLabelValues("ns", "eng", "Progressing", "False")))
+}
+
+func TestDeleteEngineMetrics(t *testing.T) {
+	resetMetrics(t)
+
+	RecordEngineInfo("ns", "eng", "fail")
+	RecordEngineConditions("ns", "eng", []metav1.Condition{
+		{Type: "Ready", Status: metav1.ConditionTrue},
+	})
+
+	// Verify metrics exist
+	assert.Equal(t, float64(1), testutil.ToFloat64(engineInfo.WithLabelValues("ns", "eng", "fail")))
+	assert.Equal(t, float64(1), testutil.ToFloat64(engineCondition.WithLabelValues("ns", "eng", "Ready", "True")))
+
+	DeleteEngineMetrics("ns", "eng")
+
+	// After deletion, collecting should yield no series for this engine.
+	count := testutil.CollectAndCount(engineInfo)
+	assert.Equal(t, 0, count, "engine info should have no series after delete")
+
+	count = testutil.CollectAndCount(engineCondition)
+	assert.Equal(t, 0, count, "engine condition should have no series after delete")
+}
+
+func TestDeleteRuleSetMetrics(t *testing.T) {
+	resetMetrics(t)
+
+	RecordRuleSetConditions("ns", "rs", []metav1.Condition{
+		{Type: "Ready", Status: metav1.ConditionTrue},
+		{Type: "Degraded", Status: metav1.ConditionFalse},
+	})
+
+	assert.Greater(t, testutil.CollectAndCount(ruleSetCondition), 0)
+
+	DeleteRuleSetMetrics("ns", "rs")
+
+	count := testutil.CollectAndCount(ruleSetCondition)
+	assert.Equal(t, 0, count, "ruleset condition should have no series after delete")
+}
+
+func TestDeleteEngineMetrics_DoesNotAffectOtherEngines(t *testing.T) {
+	resetMetrics(t)
+
+	RecordEngineInfo("ns", "eng-a", "fail")
+	RecordEngineInfo("ns", "eng-b", "allow")
+	RecordEngineConditions("ns", "eng-a", []metav1.Condition{
+		{Type: "Ready", Status: metav1.ConditionTrue},
+	})
+	RecordEngineConditions("ns", "eng-b", []metav1.Condition{
+		{Type: "Ready", Status: metav1.ConditionTrue},
+	})
+
+	DeleteEngineMetrics("ns", "eng-a")
+
+	// eng-b should still be present
+	assert.Equal(t, float64(1), testutil.ToFloat64(engineInfo.WithLabelValues("ns", "eng-b", "allow")))
+	assert.Equal(t, float64(1), testutil.ToFloat64(engineCondition.WithLabelValues("ns", "eng-b", "Ready", "True")))
+}
+
+func TestMetricMetadata(t *testing.T) {
+	resetMetrics(t)
+
+	t.Run("engine_info help and type", func(t *testing.T) {
+		RecordEngineInfo("ns", "test", "fail")
+		expected := `# HELP coraza_engine_info Info metric for Engine custom resources. Value is always 1 for active engines.
+# TYPE coraza_engine_info gauge
+`
+		err := testutil.CollectAndCompare(engineInfo, strings.NewReader(expected+
+			`coraza_engine_info{failure_policy="fail",name="test",namespace="ns"} 1
+`))
+		assert.NoError(t, err)
+	})
+
+	t.Run("engine_condition help and type", func(t *testing.T) {
+		RecordEngineConditions("ns", "test", []metav1.Condition{
+			{Type: "Ready", Status: metav1.ConditionTrue},
+		})
+		// Just verify the metric family exists with the right type
+		count := testutil.CollectAndCount(engineCondition)
+		assert.Greater(t, count, 0)
+	})
+}

--- a/internal/controller/metrics/metrics_test.go
+++ b/internal/controller/metrics/metrics_test.go
@@ -62,6 +62,19 @@ func TestRecordEngineInfo_EmptyFailurePolicy(t *testing.T) {
 	assert.Equal(t, float64(1), val)
 }
 
+func TestRecordEngineInfo_FailurePolicyChangeDoesNotLeaveStaleSeries(t *testing.T) {
+	resetMetrics(t)
+
+	RecordEngineInfo("ns", "eng", "fail")
+	assert.Equal(t, float64(1), testutil.ToFloat64(engineInfo.WithLabelValues("ns", "eng", "fail")))
+
+	RecordEngineInfo("ns", "eng", "allow")
+
+	assert.Equal(t, 1, testutil.CollectAndCount(engineInfo), "exactly one series per namespace/name")
+	assert.Equal(t, float64(1), testutil.ToFloat64(engineInfo.WithLabelValues("ns", "eng", "allow")))
+	assert.Equal(t, float64(0), testutil.ToFloat64(engineInfo.WithLabelValues("ns", "eng", "fail")))
+}
+
 func TestRecordEngineConditions_Ready(t *testing.T) {
 	resetMetrics(t)
 

--- a/internal/controller/ruleset_controller.go
+++ b/internal/controller/ruleset_controller.go
@@ -37,6 +37,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	wafv1alpha1 "github.com/networking-incubator/coraza-kubernetes-operator/api/v1alpha1"
+	crmetrics "github.com/networking-incubator/coraza-kubernetes-operator/internal/controller/metrics"
 	"github.com/networking-incubator/coraza-kubernetes-operator/internal/rulesets/cache"
 )
 
@@ -121,6 +122,7 @@ func (r *RuleSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	if err := r.Get(ctx, req.NamespacedName, &ruleset); err != nil {
 		if apierrors.IsNotFound(err) {
 			logDebug(log, req, "RuleSet", "Resource not found")
+			crmetrics.DeleteRuleSetMetrics(req.Namespace, req.Name)
 			return ctrl.Result{}, nil
 		}
 		logAPIError(log, req, "RuleSet", err, "Failed to GET", nil)
@@ -186,5 +188,6 @@ func (r *RuleSetReconciler) initializeStatus(ctx context.Context, log logr.Logge
 		return err
 	}
 	logConditionTransitions(log, req, "RuleSet", before, ruleset.Status.Conditions)
+	recordConditionMetrics("RuleSet", req.Namespace, req.Name, ruleset.Status.Conditions)
 	return nil
 }

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -36,6 +36,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	crmetrics "github.com/networking-incubator/coraza-kubernetes-operator/internal/controller/metrics"
 )
 
 // -----------------------------------------------------------------------------
@@ -248,6 +250,7 @@ func patchDegraded(
 		return err
 	}
 	logConditionTransitions(log, req, kind, before, *conditions)
+	recordConditionMetrics(kind, req.Namespace, req.Name, *conditions)
 	return nil
 }
 
@@ -282,6 +285,7 @@ func patchReady(
 		return err
 	}
 	logConditionTransitions(log, req, kind, before, *conditions)
+	recordConditionMetrics(kind, req.Namespace, req.Name, *conditions)
 	return nil
 }
 
@@ -408,6 +412,17 @@ func shouldSkipMissingFileError(err error, secretData map[string][]byte) bool {
 	}
 	_, exists := secretData[basename]
 	return exists
+}
+
+// recordConditionMetrics dispatches condition metric updates to the metrics
+// package based on the resource kind string used throughout the controllers.
+func recordConditionMetrics(kind, namespace, name string, conditions []metav1.Condition) {
+	switch kind {
+	case "Engine":
+		crmetrics.RecordEngineConditions(namespace, name, conditions)
+	case "RuleSet":
+		crmetrics.RecordRuleSetConditions(namespace, name, conditions)
+	}
 }
 
 // buildCacheReadyMessage constructs the Ready condition message after successful


### PR DESCRIPTION
## Summary

- Adds `coraza_engine_info`, `coraza_engine_condition`, and `coraza_ruleset_condition` Prometheus metrics to controller-runtime's global registry, exposing per-CR info and condition status (Ready/Degraded/Progressing) as gauges with `namespace` and `name` labels.
- New `internal/controller/metrics` package with registration, record/delete helpers, and unit tests.
- Metrics are updated after every successful `Status().Patch` (patchReady, patchDegraded, Progressing-only paths) and cleaned up on CR deletion (NotFound).

Closes #66

## Test plan

- [ ] Unit tests in `internal/controller/metrics/metrics_test.go` cover registration, recording, transitions, deletion, and isolation between CRs.
- [ ] Existing controller envtest tests continue to pass (metric recording is additive and does not change reconciler behavior).
- [ ] Verify metrics endpoint exposes `coraza_engine_info`, `coraza_engine_condition`, `coraza_ruleset_condition` after deploying to a cluster.


Made with [Cursor](https://cursor.com)